### PR TITLE
Attempt new login on 401 error

### DIFF
--- a/x2gbfs/providers/fleetster.py
+++ b/x2gbfs/providers/fleetster.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from random import random
 from time import sleep
 from typing import Dict, Generator, Optional
 
@@ -17,7 +18,7 @@ class FleetsterAPI:
     """
 
     #: Number of times a login is attempted before an error is thrown on 401 response
-    MAX_LOGIN_ATTEMPTS = 1
+    MAX_LOGIN_ATTEMPTS = 5
 
     token: Optional[str] = None
     api_url: Optional[str] = None
@@ -69,7 +70,10 @@ class FleetsterAPI:
                 # a session token with the same credentials, invalidating our token
 
                 # Give potentially competing clients some time to complete their requests
-                seconds_to_sleep = 0.5 * no_of_login_attempts
+                # exponential back-offs plus some randomised "jitter" to prevent the https://en.wikipedia.org/wiki/Thundering_herd_problem
+                seconds_to_sleep = (
+                    0.5 * (1 + random() / 10) * no_of_login_attempts**2  # noqa: S311 (no cryptographic purpose)
+                )
                 logger.warn(
                     f'Requested token {self.token} was invalid, waiting for {seconds_to_sleep} seconds before retry'
                 )

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -2,10 +2,12 @@ import json
 import logging
 import os
 from argparse import ArgumentParser
+from random import random
 from time import sleep
 from typing import Any, Dict, List
 
 from decouple import config
+from requests.exceptions import HTTPError
 
 from x2gbfs.gbfs import BaseProvider, GbfsTransformer, GbfsWriter
 from x2gbfs.providers import Deer, FleetsterAPI
@@ -37,12 +39,12 @@ def main(providers: List[str], output_dir: str, base_url: str, interval: int = 0
         for provider in providers:
             try:
                 generate_feed_for(provider, output_dir, base_url)
-            except Exception:
+            except HTTPError:
                 logger.exception(f'Generating feed for {provider} failed!')
                 error_occured = True
 
         if should_loop_infinetly:
-            sleep(interval)
+            sleep(interval + random() * interval / 10)  # noqa: S311 (no cryptographic purpose)
         else:
             # In case an error occured, we terminate with exit code 1
             exit(error_occured)


### PR DESCRIPTION
This PR:
* attempts to login again in case of a 401 reply, which can happen when the same credentials are used in a different session
* catches and logs exceptions when the generation of a feed fails for a provider
* in single-run mode, terminates with exit code 1 when feed generation was not successful for at least one provider

---

fixes #12