### PR TITLE
Cantamen: Introduce configurable response max size, increase timeout to 10s

### DIFF
--- a/x2gbfs/providers/api/ixsi.py
+++ b/x2gbfs/providers/api/ixsi.py
@@ -5,7 +5,7 @@ from websockets.sync.client import connect
 
 
 class IxsiAPI:
-    def __init__(self, system_id: str, uri: str, timeout=5):
+    def __init__(self, system_id: str, uri: str, timeout=5, max_size=2**24):
         """
         Send a message to a recipient.
 
@@ -16,9 +16,10 @@ class IxsiAPI:
         self.system_id = system_id
         self.uri = uri
         self.timeout = timeout
+        self.max_size = max_size
 
     def _request(self, message):
-        with connect(self.uri) as websocket:
+        with connect(self.uri, max_size=self.max_size) as websocket:
             websocket.send(message)
             return websocket.recv(timeout=self.timeout)
 

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -19,7 +19,7 @@ class CantamenIXSIProvider(BaseProvider):
     Generic Stadtmobil provider to retrieve sharing data via IXSI an convert it to GBFS.
     It can be configured via ENV variables:
     * CANTAMEN_IXSI_API_URL (required): an IXSIv5 service endpoint url
-    * CANTAMEN_IXSI_API_TIMEOUT (specified in seconds, optional, default 5)
+    * CANTAMEN_IXSI_API_TIMEOUT (specified in seconds, optional, default 10)
     * CANTAMEN_IXSI_RESPONSE_MAX_SIZE (specified in bytes, optional, default 2**24)
 
     This Provider expects the config dict to provide the followig information:
@@ -84,7 +84,7 @@ class CantamenIXSIProvider(BaseProvider):
 
     def __init__(self, feed_config):
         self.api_url = config('CANTAMEN_IXSI_API_URL')
-        self.api_timeout = config('CANTAMEN_IXSI_API_TIMEOUT', 5)
+        self.api_timeout = config('CANTAMEN_IXSI_API_TIMEOUT', 10)
         self.api_response_max_size = config('CANTAMEN_IXSI_RESPONSE_MAX_SIZE', 2**24)
         self.config = feed_config
 

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -20,6 +20,7 @@ class CantamenIXSIProvider(BaseProvider):
     It can be configured via ENV variables:
     * CANTAMEN_IXSI_API_URL (required): an IXSIv5 service endpoint url
     * CANTAMEN_IXSI_API_TIMEOUT (specified in seconds, optional, default 5)
+    * CANTAMEN_IXSI_RESPONSE_MAX_SIZE (specified in bytes, optional, default 2**24)
 
     This Provider expects the config dict to provide the followig information:
     * provider_id: ID of the provider to be retrieved
@@ -84,12 +85,15 @@ class CantamenIXSIProvider(BaseProvider):
     def __init__(self, feed_config):
         self.api_url = config('CANTAMEN_IXSI_API_URL')
         self.api_timeout = config('CANTAMEN_IXSI_API_TIMEOUT', 5)
+        self.api_response_max_size = config('CANTAMEN_IXSI_RESPONSE_MAX_SIZE', 2**24)
         self.config = feed_config
 
     def _load_response(self) -> Dict[str, Any]:
         if not self.cached_response:
             provider_id = self.config['provider_id']
-            data = IxsiAPI(self.config['system_id'], self.api_url, self.api_timeout).result_for_provider(provider_id)
+            data = IxsiAPI(
+                self.config['system_id'], self.api_url, self.api_timeout, self.api_response_max_size
+            ).result_for_provider(provider_id)
             base_data = xmltodict.parse(data)['Ixsi']['Response']['BaseData']
             self._parse_attributes(base_data['Attributes'])
             self.cached_response = base_data


### PR DESCRIPTION
This PR adds a configurable max response size for cantamen web socket responses.

In addition, the CANTAMEN_IXSI_API_TIMEOUT is increased from 5s to 10s.