### PR TITLE
add system_information._feed_notice

### DIFF
--- a/config/my-e-car.json
+++ b/config/my-e-car.json
@@ -309,7 +309,8 @@
             "terms_last_updated": "2022-02-15",
             "terms_url": "https://www.my-e-car.de/agb/",
             "timezone": "Europe/Berlin",
-            "url": "https://www.my-e-car.de/"
+            "url": "https://www.my-e-car.de/",
+	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
         }
     },
     "system_id": "10024",

--- a/config/stadtmobil_suedbaden.json
+++ b/config/stadtmobil_suedbaden.json
@@ -275,7 +275,8 @@
             "terms_last_updated": "2021-02-01",
             "terms_url": "https://www.stadtmobil-suedbaden.de/agb/",
             "timezone": "Europe/Berlin",
-            "url": "https://www.stadtmobil-suedbaden.de/"
+            "url": "https://www.stadtmobil-suedbaden.de/",
+	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
         }
     },
     "system_id": "10024",


### PR DESCRIPTION
I tested this extension on MD-IPL-TEST:

adm_nvbw_froehlingha@MD-IPL-TEST:~/ipl/x2gbfs$ CANTAMEN_IXSI_API_URL=wss://de1.cantamen.de/ixsi/v5 python3 -m x2gbfs.x2gbfs -p stadtmobil_suedbaden -b 'file:out'
INFO:x2gbfs.cantamen:Skip station Test/Geschäftsstelle (2246) as it has coords (0,0)
INFO:x2gbfs.base_provider:Vehicle 7831 is assigned to inexistant station 2246, it will be removed from feed
INFO:x2gbfs.base_provider:Vehicle 7828 is assigned to inexistant station 2246, it will be removed from feed
INFO:x2gbfs.base_provider:Vehicle 6867 is assigned to inexistant station 2246, it will be removed from feed
INFO:x2gbfs.base_provider:Vehicle 6866 is assigned to inexistant station 2246, it will be removed from feed
INFO:x2gbfs:Updated feeds for stadtmobil_suedbaden

The resulting system_information.json file contains a _feed_notice entry.