### PR TITLE
feat: treat vehicles as unreserved by default

### DIFF
--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -266,7 +266,7 @@ class CantamenIXSIProvider(BaseProvider):
         current_fuel_percent = current_charge_level / 100.0
         return {
             'bike_id': bookee['ID'],
-            'is_reserved': True,  # No realtime information available, set to reserved
+            'is_reserved': False,  # No realtime information available, set to False
             'is_disabled': False,
             'station_id': bookee['PlaceID'],
             'vehicle_type_id': vehicle_type_id,


### PR DESCRIPTION
As requested by the MobiData BW team: This PR sets vehicle.is_reserved to False for Cantamen based providers, even though we have no realtime information.

