### PR TITLE
Add Stadtmobil Stuttgart

### DIFF
--- a/config/stadtmobil_stuttgart.json
+++ b/config/stadtmobil_stuttgart.json
@@ -1,0 +1,242 @@
+{
+    "feed_data": {
+        "pricing_plans": [
+            {
+                "currency": "EUR",
+                "description": "Classik-Tarif: 1,40€/h. Nachtpreis zwischen 0h und 7h: 0€. 0,25€/km bis 100km, danach 0,23€/km. Zuzüglich Grundgebühr. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "A Toyota Aygo",
+                "per_min_pricing": [
+                    {
+                        "start": 0,
+                        "end": 1020,
+                        "interval": 60,
+                        "rate": 1.40
+                    },
+                    {
+                        "start": 1020,
+                        "end": 1440,
+                        "interval": 60,
+                        "rate": 0
+                    }
+                ],
+                "per_km_pricing": [
+                    {
+                        "start": 0,
+                        "end": 100,
+                        "interval": 1,
+                        "rate": 0.25
+                    },
+                    {
+                        "start": 100,
+                        "interval": 1,
+                        "rate": 0.23
+                    }
+                ],
+                "plan_id": "micro",
+                "price": 0,
+                "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Classik-Tarif: 2,20€/h. Nachtpreis zwischen 0h und 7h: 0€. 0,27€/km bis 100km, danach 0,24€/km bis 700km, danach 0,21€/km. Zuzüglich Grundgebühr. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "B Opel Corsa, Opel Corsa (Elektro), Opel Adam, Renault ZOE (Elektro), Toyota Yaris Hybrid, Opel Cargo Kastenwagen, Renault Kangoo Kastenwagen",
+                "per_min_pricing": [
+                    {
+                        "start": 0,
+                        "end": 1020,
+                        "interval": 60,
+                        "rate": 2.20
+                    },
+                    {
+                        "start": 1020,
+                        "end": 1440,
+                        "interval": 60,
+                        "rate": 0
+                    }
+                ],
+                "per_km_pricing": [
+                    {
+                        "start": 0,
+                        "end": 100,
+                        "interval": 1,
+                        "rate": 0.27
+                    },
+                    {
+                        "start": 100,
+                        "end": 700,
+                        "interval": 1,
+                        "rate": 0.24
+                    },
+                    {
+                        "start": 700,
+                        "interval": 1,
+                        "rate": 0.21
+                    }
+                ],
+                "plan_id": "mini",
+                "price": 0,
+                "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Classik-Tarif: 2,80€/h. Nachtpreis zwischen 0h und 7h: 0€. 0,31€/km bis 100km, danach 0,26€/km bis 700km, danach 0,22€/km. Zuzüglich Grundgebühr. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "C Opel Astra Kombi, Toyota Auris/Corolla Kombi Hybrid, Opel Life Hochdachkombi",
+                "per_min_pricing": [
+                    {
+                        "start": 0,
+                        "end": 1020,
+                        "interval": 60,
+                        "rate": 2.80
+                    },
+                    {
+                        "start": 1020,
+                        "end": 1440,
+                        "interval": 60,
+                        "rate": 0
+                    }
+                ],
+                "per_km_pricing": [
+                    {
+                        "start": 0,
+                        "end": 100,
+                        "interval": 1,
+                        "rate": 0.31
+                    },
+                    {
+                        "start": 100,
+                        "end": 700,
+                        "interval": 1,
+                        "rate": 0.26
+                    },
+                    {
+                        "start": 700,
+                        "interval": 1,
+                        "rate": 0.22
+                    }
+                ],
+                "plan_id": "small",
+                "price": 0,
+                "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Classik-Tarif: 3,20€/h. Nachtpreis zwischen 0h und 7h: 1,00€. 0,34€/km bis 100km, danach 0,30€/km. Zuzüglich Grundgebühr. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "D BMW 216d Active Tourer Opel Zafira Kleinbus, Ford Custom Kleinbus, Renault Trafic (8-Sitzer), Renault Trafic (9-Sitzer",
+                "per_min_pricing": [
+                    {
+                        "start": 0,
+                        "end": 1020,
+                        "interval": 60,
+                        "rate": 3.20
+                    },
+                    {
+                        "start": 1020,
+                        "end": 1440,
+                        "interval": 60,
+                        "rate": 1.00
+                    }
+                ],
+                "per_km_pricing": [
+                    {
+                        "start": 0,
+                        "end": 100,
+                        "interval": 1,
+                        "rate": 0.34
+                    },
+                    {
+                        "start": 100,
+                        "interval": 1,
+                        "rate": 0.30
+                    }
+                ],
+                "plan_id": "large",
+                "price": 0,
+                "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Classik-Tarif: 4,20€/h. Nachtpreis zwischen 0h und 7h: 2,00€. 0,38€/km bis 100km, danach 0,32€/km. Zuzüglich Grundgebühr. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "F Ford Transit Transporter",
+                "per_min_pricing": [
+                    {
+                        "start": 0,
+                        "end": 1020,
+                        "interval": 60,
+                        "rate": 4.20
+                    },
+                    {
+                        "start": 1020,
+                        "end": 1440,
+                        "interval": 60,
+                        "rate": 2.00
+                    }
+                ],
+                "per_km_pricing": [
+                    {
+                        "start": 0,
+                        "end": 100,
+                        "interval": 1,
+                        "rate": 0.38
+                    },
+                    {
+                        "start": 100,
+                        "interval": 1,
+                        "rate": 0.32
+                    }
+                ],
+                "plan_id": "transporter",
+                "price": 0,
+                "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
+            }
+        ],
+        "system_information": {
+            "email": "info@stadtmobil-stuttgart.de",
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de",
+            "license_url": "https://www.govdata.de/dl-de/by-2-0",
+            "license_id": "DL-DE-BY-2.0",
+            "attribution_organization_name": "stadtmobil carsharing AG",
+            "attribution_url": "https://stuttgart.stadtmobil.de/",
+            "name": "Stadtmobil Stuttgart",
+            "operator": "stadtmobil carsharing AG",
+            "phone_number": "+49 (0)711 - 94 54 36 36",
+            "privacy_url": "https://stuttgart.stadtmobil.de/datenschutz/",
+            "purchase_url": "https://stuttgart.stadtmobil.de/privatkunden/kunde-werden/",
+            "rental_apps": {
+                "android": {
+                    "discovery_uri": "cantamen-interapp-csd://add_booking",
+                    "store_uri": "https://play.google.com/store/apps/details?id=de.cantamen.carsharing.deutschland"
+                },
+                "ios": {
+                    "discovery_uri": "cantamen-interapp-csd://add_booking",
+                    "store_uri": "https://apps.apple.com/de/app/carsharing-deutschland/id1075669223"
+                }
+            },
+            "system_id": "stadtmobil_stuttgart",
+            "terms_last_updated": "2020-02-01",
+            "terms_url": "https://stuttgart.stadtmobil.de/agb/",
+            "timezone": "Europe/Berlin",
+            "url": "https://stuttgart.stadtmobil.de/",
+	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
+        }
+    },
+    "system_id": "10024",
+    "provider_id": 3,
+    "url_templates": {
+        "station": {
+            "android": "cantamen-interapp-csd://add_booking?openPlace={placeId}",
+            "ios": "cantamen-interapp-csd://add_booking?openPlace={placeId}",
+            "web": "https://ewi3.cantamen.de/?openPlace={placeId}"
+        },
+        "vehicle": {
+            "android": "cantamen-interapp-csd://add_booking?openBookee={bookeeId}",
+            "ios": "cantamen-interapp-csd://add_booking?openBookee={bookeeId}",
+            "web": "https://ewi3.cantamen.de/?openBookee={bookeeId}"
+        }
+    }
+}

--- a/config/stadtmobil_stuttgart.json
+++ b/config/stadtmobil_stuttgart.json
@@ -33,7 +33,7 @@
                         "rate": 0.23
                     }
                 ],
-                "plan_id": "micro",
+                "plan_id": "mini",
                 "price": 0,
                 "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
             },
@@ -75,7 +75,7 @@
                         "rate": 0.21
                     }
                 ],
-                "plan_id": "mini",
+                "plan_id": "small",
                 "price": 0,
                 "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
             },
@@ -117,7 +117,7 @@
                         "rate": 0.22
                     }
                 ],
-                "plan_id": "small",
+                "plan_id": "medium",
                 "price": 0,
                 "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
             },
@@ -153,7 +153,7 @@
                         "rate": 0.30
                     }
                 ],
-                "plan_id": "large",
+                "plan_id": "van",
                 "price": 0,
                 "url": "https://stuttgart.stadtmobil.de/media/user_upload/downloads_privatkunden/stuttgart/Tarifordnung_05_2022.pdf"
             },

--- a/x2gbfs/providers/__init__.py
+++ b/x2gbfs/providers/__init__.py
@@ -1,4 +1,4 @@
-from .cantamen import MyECarProvider, StadtmobilSuedbadenProvider
+from .cantamen import CantamenIXSIProvider
 from .deer import Deer
 from .example import ExampleProvider
 from .fleetster import FleetsterAPI

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -121,6 +121,9 @@ class CantamenIXSIProvider(BaseProvider):
     def _all_bookees(self) -> Generator[Dict[str, Any], None, None]:
         bookees = self._load_response()['Bookee']
         for bookee in bookees:
+            if bookee.get('Class') is None:
+                logger.info(f'Bookee {bookee["ID"]} has no Class and will be ignored')
+                continue
             yield bookee
 
     def _all_places(self) -> Generator[Dict[str, Any], None, None]:

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -218,7 +218,9 @@ class CantamenIXSIProvider(BaseProvider):
         # Vehicles usually have their license plate (in parentheses) appended in their name.
         # We cut this of by cutting of all text starting from the rightmost opening parenthesis.
         # A single license plate (X-XXX XXX (BÜ)) is handled explicitly here
-        name = bookee_name[0 : bookee_name.replace('(BÜ)', '').rfind('(')].strip()
+        name = bookee_name.replace('(BÜ)', '')
+        name = re.sub(r'\(\d+\)', '', name)
+        name = name[0 : name.rfind('(')].strip() if name.rfind('(') > 0 else name.strip()
         # range is spelled in various ways (e.g. 'bis XXXkm', '< XXXkm', '<XXXkm'), we homogenize ot '<XXXkm'':
         return name.replace(' bis ', ' <').replace('< ', '<')
 

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -86,7 +86,7 @@ class CantamenIXSIProvider(BaseProvider):
 
     def __init__(self, feed_config):
         self.api_url = config('CANTAMEN_IXSI_API_URL')
-        self.api_timeout = config('CANTAMEN_IXSI_API_TIMEOUT', 10)
+        self.api_timeout = int(config('CANTAMEN_IXSI_API_TIMEOUT', 10))
         self.api_response_max_size = config('CANTAMEN_IXSI_RESPONSE_MAX_SIZE', 2**24)
         self.config = feed_config
         self.pricing_plan_ids = [plan['plan_id'] for plan in feed_config['feed_data']['pricing_plans']]

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -11,12 +11,11 @@ from requests.exceptions import HTTPError
 
 from x2gbfs.gbfs import BaseProvider, GbfsTransformer, GbfsWriter
 from x2gbfs.providers import (
+    CantamenIXSIProvider,
     Deer,
     ExampleProvider,
     FleetsterAPI,
     LastenVeloFreiburgProvider,
-    MyECarProvider,
-    StadtmobilSuedbadenProvider,
     VoiRaumobil,
 )
 
@@ -43,10 +42,8 @@ def build_extractor(provider: str, feed_config: Dict[str, Any]) -> BaseProvider:
         api_password = config('VOI_PASSWORD')
 
         return VoiRaumobil(api_url, api_user, api_password)
-    if provider in ['stadtmobil_suedbaden']:
-        return StadtmobilSuedbadenProvider(feed_config)
-    if provider in ['my-e-car']:
-        return MyECarProvider(feed_config)
+    if provider in ['my-e-car'] or provider.startswith('stadtmobil_'):
+        return CantamenIXSIProvider(feed_config)
 
     raise ValueError(f'Unknown config {provider}')
 


### PR DESCRIPTION
This PR adds Stadtmobil Stuttgart.

Besides adding some Stuttgart specific name/propulsion handling, this PR removes the need for provider specific subclasses  by reading the available pricing plans directly from the config.