### PR TITLE
Add Stadtwerk Tauberfranken / MOQO

### DIFF
--- a/config/stadtwerk_tauberfranken.json
+++ b/config/stadtwerk_tauberfranken.json
@@ -1,0 +1,72 @@
+{
+    "feed_data": {
+        "pricing_plans": [
+            {
+                "currency": "EUR",
+                "description": "Tarif: 0,20€/km zzgl. 3€/h bzw. 30€/Tag bzw. 50€ am Wochenende (Freitag 17:00 Uhr bis Sonntag 23:59 Uhr). Einmalige Registrierung für 4,90€ erforderlich. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "Tarif",
+                "per_km_pricing": [
+                    {
+                        "interval": 1,
+                        "rate": 0.2,
+                        "start": 0
+                    }
+                ],
+                "per_min_pricing": [
+                    {
+                        "end": 600,
+                        "interval": 60,
+                        "rate": 3,
+                        "start": 0
+                    },
+                    {
+                        "end": 1440,
+                        "interval": 1040,
+                        "rate": 0,
+                        "start": 600
+                    },
+                    {
+                        "interval": 1440,
+                        "rate": 30,
+                        "start": 1440
+                    }
+                ],
+                "plan_id": "tarif",
+                "price": 0,
+                "url": "https://stadtwerk-tauberfranken.de/elektromobilitaet/e-carsharing/"
+            }
+        ],
+        "system_information": {
+            "attribution_organization_name": "Stadtwerk Tauberfranken GmbH",
+            "attribution_url": "https://stadtwerk-tauberfranken.de/",
+            "email": "info@taubermobil.de",
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de",
+            "license_id": "DL-DE-BY-2.0",
+            "license_url": "https://www.govdata.de/dl-de/by-2-0",
+            "name": "Stadtwerk Tauberfranken",
+            "operator": "Stadtwerk Tauberfranken GmbH in Kooperation mit Taubermobil e.V.",
+            "privacy_url": "https://stadtwerk-tauberfranken.de/datenschutz/",
+            "purchase_url": "https://portal.moqo.de/js_sign_up/tauberfranken-car-sharing-offentlich?context=in_app&scheme=moqo#/account",
+            "rental_apps": {
+                "android": {
+                    "discovery_uri": "https://moqo.de/yet_unknown",
+                    "store_uri": "https://play.google.com/store/apps/details?id=de.moqo.work&hl=de"
+                },
+                "ios": {
+                    "discovery_uri": "https://moqo.de/yet_unknown",
+                    "store_uri": "https://apps.apple.com/de/app/moqo/id1385011262"
+                }
+            },
+            "system_id": "stadtwerk-tauberfranken",
+            "terms_last_updated": "2024-01-16",
+            "terms_url": "https://stadtwerk-tauberfranken.de/elektromobilitaet/e-carsharing/",
+            "timezone": "Europe/Berlin",
+            "url": "https://stadtwerk-tauberfranken.de/elektromobilitaet/e-carsharing/"
+        }
+    },
+    "provider_data": {
+        "team_id": "1100108681"
+    }
+}

--- a/docs/mappings/moqo_gbfs_2.3_mapping.md
+++ b/docs/mappings/moqo_gbfs_2.3_mapping.md
@@ -1,0 +1,199 @@
+# MOQO to GBFS Mapping
+
+This document map MOQO's sharing API to GBFS.
+
+# Reference version
+
+This documentation refers to **[v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md)**.
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [General Information](#general-information)
+* [Open Issues or Questions](#open-issues-or-questions)
+* [Files](#files)
+    * [gbfs.json](#gbfsjson)
+    * [gbfs_versions.json](#gbfs_versionsjson) *(added in v1.1)*
+    * [system_information.json](#system_informationjson)
+    * [vehicle_types.json](#vehicle_typesjson) *(added in v2.1)*
+    * [station_information.json](#station_informationjson)
+    * [station_status.json](#station_statusjson)
+    * [free_bike_status.json](#free_bike_statusjson)
+    * [system_hours.json](#system_hoursjson)
+    * [system_calendar.json](#system_calendarjson)
+    * [system_regions.json](#system_regionsjson)
+    * [system_pricing_plans.json](#system_pricing_plansjson)
+    * [system_alerts.json](#system_alertsjson)
+    * [geofencing_zones.json](#geofencing_zonesjson) *(added in v2.1)*
+
+## Introduction
+
+This specification describes the mapping of MOQO's API to GBFS.
+
+
+## General Information
+
+This section gives a high level overview of the sharing provider's API and the defined mapping to GBFS.
+
+Official API documentation is access restricted, hence not included.
+
+Examples from th
+
+
+## Open Issues or Questions
+
+Open questions are managed as [issues](https://github.com/mobidata-bw/x2gbfs/issues?q=is%3Aissue+is%3Aopen+label%moqo). They should be tagged with `moqo`.
+
+
+## Files
+
+### gbfs.json
+
+Standard file, feed will be provided in feed language `de` only.
+
+### gbfs_versions.json
+
+Optional file, will not be provided. Only GBFSv2.3 supported.
+
+### system_information.json
+
+System information is manually extracted from the providers homepage. Only the real configuration in e.g. [config/stadtwerk-tauberfranken.json](../../config/stadtwerk-tauberfranken.json) is relevant.
+
+
+### vehicle_types.json
+
+Vehicle Types, vehicles are extracted from the `cars` endpoint, extracting this from the returned cars.
+
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`vehicle_type_id` |  lowercased `row['car_model_name']`, spaces transformed in underscore
+`form_factor` | `row['vehicle_type']` mapped to GBFS vehicle types.
+`rider_capacity`| -
+`cargo_volume_capacity` | -
+`cargo_load_capacity` | -
+`propulsion_type` | `row['fuel_type']` mapped to GBFS vehicle types.
+`eco_label` | -
+`max_range_meters` | Not availabe via API, set to `250.000`
+`name` | `row['car_model_name']`
+`g_CO2_km` | -
+`vehicle_image` | -
+`make` | first word of `row['car_model_name']`
+`model` | all words after the first word of `row['car_model_name']`
+`wheel_count` | -
+`max_permitted_speed` | -
+`rated_power` | -
+`default_reserve_time` | -
+`return_constraint`| `roundtrip`
+`vehicle_assets`| -
+`default_pricing_plan_id`| `tarif` (current provided only has one pricing plan, might be overwritten in subclasses)
+`pricing_plan_ids`| -
+
+
+### station_information.json
+
+Station information is extracted from `parkings` endpoint.
+
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`station_id` | `row['id']`
+`name` | `row['name']`
+`short_name` | -
+`lat` | `row['center']['lat']`
+`lon` | `row['center']['lon']`
+`address` | `row['town'] + ', ' + row['street'] + ' ' + row['street_number']`
+`cross_street` | -
+`region_id` | -
+`post_code` |  `row['zipcode']`
+`rental_methods` |`['key']`
+`is_virtual_station`| -
+`station_area` | -
+`parking_type` | -
+`parking_hoop` | -
+`contact_phone` | -
+`capacity` | -
+`vehicle_capacity`  |  `row['capacity_max']`
+`vehicle_type_capacity` | _deduced from vehicles assigned to this station free_bike_status.station_id_
+`is_valet_station`  | -
+`is_charging_station` |  -
+`rental_uris` | -
+
+
+### station_status.json
+
+*Describe endpoint from which information is extracted and potential filter rules to be applied*
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`station_id` | `row['lon']_row['lat']`
+`num_bikes_available` | _deduced by x2gbfs from free_bike_status.station_id_
+`vehicle_types_available` | _deduced by x2gbfs from free_bike_status.station_id_
+`num_docks_available` | -
+`vehicle_docks_available` | -
+`num_docks_disabled` | -
+`is_installed` | `True`
+`is_renting` | `True` (Note: the API does not return opening hours information yet)
+`is_returning` | `True` (Note: the API does not return opening hours information yet)
+`last_reported` | `row['UTC Timestamp']`
+
+
+### free_bike_status.json
+
+Free vehicles are extracted from `cars` endpoint. As currently unavailable cars have no `latest_parking` set, we filter them out. We request availablity status as being available in the next 3 hours.
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`bike_id` | `row['id']`
+`lat` | - Vehicles are at station, so we don't provide coords
+`lon` | - Vehicles are at station, so we don't provide coords
+`is_reserved` | `row['available'] is not True`
+`is_disabled` | -
+`rental_uris` | -
+`vehicle_type_id` | see section vehicle_types
+`last_reported` | curent time
+`license_plate`: `row['license'].split('|')[0].strip()` (at least Stadtwerk Tauberfranken seems to append station name after the license plate)
+`current_range_meters` | `vehicle_type['max_rang_meters'] * vehicle['fuel_level'] / 100.0`
+`current_fuel_percent` | `vehicle['fuel_level'] / 100.0`
+`station_id` | `row['laatest_parking']['id']`, if set
+`home_station_id` | -
+`pricing_plan_id` | -
+`vehicle_equipment` | -
+`available_until` | - (API does not provide this information explicitly)
+
+
+### system_hours.json
+
+No endpoint.
+
+### system_calendar.json
+
+No endpoint.
+
+### system_regions.json
+
+No endpoint.
+
+### system_pricing_plans.json
+
+No endpoint. Manually de
+
+### system_alerts.json
+
+No endpoint.
+
+### geofencing_zones.json
+
+No endpoint.
+
+## Deep Links
+
+Deep links seem not to be available for vehicles yet.

--- a/x2gbfs/gbfs/gbfs_transformer.py
+++ b/x2gbfs/gbfs/gbfs_transformer.py
@@ -70,9 +70,11 @@ class GbfsTransformer:
                 }
             )
 
-        for station_id in vehicle_types_per_station.keys():
-            if station_id in status_map:
+        for station_id in status_map.keys():
+            if station_id in vehicle_types_per_station:
                 self._update_station_availability_status(vehicle_types_per_station[station_id], status_map[station_id])
+            else:
+                status_map[station_id]['vehicle_types_available'] = []
 
     def _update_station_availability_status(
         self, vt_available: List[Dict[str, Any]], station_status: Dict[str, Any]

--- a/x2gbfs/providers/__init__.py
+++ b/x2gbfs/providers/__init__.py
@@ -3,4 +3,5 @@ from .deer import Deer
 from .example import ExampleProvider
 from .fleetster import FleetsterAPI
 from .lastenvelo_fr import LastenVeloFreiburgProvider
+from .moqo import StadtwerkTauberfrankenProvider
 from .voi_raumobil import VoiRaumobil

--- a/x2gbfs/providers/moqo.py
+++ b/x2gbfs/providers/moqo.py
@@ -1,0 +1,255 @@
+import logging
+from datetime import datetime
+from typing import Any, Dict, Generator, Optional, Tuple
+
+from decouple import config
+
+from x2gbfs.gbfs.base_provider import BaseProvider
+from x2gbfs.util import get
+
+logger = logging.getLogger('x2gbfs.moqo')
+
+
+class MoqoProvider(BaseProvider):
+    FUEL_TYPE_MAPPING = {
+        'electric': 'electric',
+        'super_petrol': 'combustion',
+        'natural_gas': 'combustion',
+        'liquid_gas': 'combustion',
+        'bio_gas': 'combustion',
+        'hybrid_electric_petrol': 'hybrid',
+        'hybrid_electric_diesel': 'hybrid',
+        'hydrogen': 'hydrogen_fuel_cell',
+        'plugin_hybrid_petrol': 'plug_in_hybrid',
+        'plugin_hybrid_diesel': 'plug_in_hybrid',
+    }
+
+    CARS_REQUEST_PARAMS = {
+        'fields[cars]': 'id,license,fuel_type,vehicle_type,car_type,fuel_level',  # is cruising_range available?
+        'extra_fields[cars]': 'car_model_name,available',
+        'include': 'latest_parking',  # vehicle_categories is not helpful for stadtwerke-tauberfranken
+        'fields[latest_parking]': 'id',
+        'page[size]': '200',
+    }
+
+    DEFAULT_CURRENT_FUEL_PERCENT = 0.5
+    DEFAULT_MAX_RANGE_METERS = 250000
+    MINIMUM_REQUIRED_AVAILABLE_TIMESPAN_IN_SECONDS = 60 * 60 * 3  # 3 hours
+
+    def __init__(self, feed_config: dict[str, Any]):
+        self.api_token = config('MOQO_API_TOKEN')
+        self.config = feed_config
+        self.team_id = feed_config['provider_data']['team_id']
+        self.api_url = f'http://portal.moqo.de/d/{self.team_id}/api/graph/'
+
+    def load_stations(self, default_last_reported: int) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """
+        Retrieves stations from the providers API and converts them
+        into gbfs station infos and station status.
+        Returns dicts where the key is the station_id and values
+        are station_info/station_status.
+
+        For free floating only providers, this method needs not to be overwritten.
+
+        Note: station status' vehicle availabilty currently will be calculated
+        using vehicle information's station_id, in case it is defined by this
+        provider.
+        """
+
+        gbfs_station_infos_map: dict[str, dict] = {}
+        gbfs_station_status_map: dict[str, dict] = {}
+
+        for elem in self._get_paginated('parkings'):
+            self._extract_from_parkings(elem, gbfs_station_infos_map, gbfs_station_status_map, default_last_reported)
+
+        return gbfs_station_infos_map, gbfs_station_status_map
+
+    def load_vehicles(self, default_last_reported: int) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """
+        Retrieves vehicles and vehicle types from provider's API and converts them
+        into gbfs vehicles, vehicle_types.
+        Returns dicts where the key is the vehicle_id/vehicle_type_id and values
+        are vehicle/vehicle_type.
+        """
+        gbfs_vehicle_types_map: dict[str, dict] = {}
+        gbfs_vehicles_map: dict[str, dict] = {}
+
+        params = dict(self.CARS_REQUEST_PARAMS)
+        params['filter[from]'] = self._format_timestamp(default_last_reported)
+        params['filter[until]'] = self._format_timestamp(
+            default_last_reported + self.MINIMUM_REQUIRED_AVAILABLE_TIMESPAN_IN_SECONDS
+        )
+
+        for elem in self._get_paginated('cars', params):
+            self._extract_from_vehicles(elem, gbfs_vehicles_map, gbfs_vehicle_types_map)
+
+        return gbfs_vehicle_types_map, gbfs_vehicles_map
+
+    @staticmethod
+    def _format_timestamp(timestamp: int) -> str:
+        return datetime.fromtimestamp(timestamp).strftime('%Y-%m-%dT%H:%M')
+
+    def _get_paginated(self, element_type: str, params: Optional[dict[str, str]] = None):
+        url = self.api_url + element_type
+        headers = {'Authorization': f'Bearer {self.api_token}', 'accept': 'application/json'}
+        page = 1
+        while True:
+            request_params = dict(params) if params is not None else {}
+            request_params['page[number]'] = str(page)
+            json_response = get(url, params=request_params, headers=headers).json()
+
+            if 'data' in json_response:
+                for elem in json_response['data']:
+                    yield elem
+            else:
+                logger.warning(f'Response to {url} did not contain {element_type}')
+                logger.warning(json_response)
+                return
+
+            if json_response.get('pagination', {}).get('next_page'):
+                page += 1
+            else:
+                break
+
+    def _extract_from_parkings(
+        self,
+        elem: dict[str, Any],
+        gbfs_station_infos_map: dict[str, dict],
+        gbfs_station_status_map: dict[str, dict],
+        default_last_reported: int,
+    ) -> None:
+        station_id = elem['id']
+
+        center = elem['center']
+        station = {
+            'lat': center['lat'],
+            'lon': center['lng'],
+            'name': elem['name'],
+            'station_id': str(elem['id']),
+            'address': elem['town'] + ', ' + elem['street'] + ' ' + elem['street_number'],
+            'post_code': elem['zipcode'],
+            'rental_methods': ['key'],
+        }
+
+        if elem['capacity_max']:
+            station['capacity'] = elem['capacity_max']
+
+        gbfs_station_infos_map[station_id] = station
+
+        gbfs_station_status_map[station_id] = {
+            'num_bikes_available': 0,
+            'vehicle_types_available': {},
+            'is_renting': True,
+            'is_installed': True,
+            'is_returning': True,
+            'station_id': str(elem['id']),
+            'last_reported': default_last_reported,
+        }
+
+    def _extract_from_vehicles(
+        self,
+        vehicle: dict[str, Any],
+        vehicles: dict[str, Any],
+        vehicle_types: dict[str, Any],
+    ) -> None:
+        vehicle_type_id = self._extract_vehicle_type(vehicle_types, vehicle)
+        vehicle_id = vehicle['id']
+        current_fuel_percent = (
+            vehicle['fuel_level'] / 100.0 if 'fuel_level' in vehicle else self.DEFAULT_CURRENT_FUEL_PERCENT
+        )
+        current_range_meters = vehicle_types[vehicle_type_id]['max_range_meters'] * current_fuel_percent
+        gbfs_vehicle = {
+            'bike_id': str(vehicle_id),
+            'is_reserved': vehicle['available'] is not True,
+            'is_disabled': False,
+            'vehicle_type_id': vehicle_type_id,
+            'license_plate': vehicle['license'].split('|')[0].strip(),
+            'current_range_meters': current_range_meters,
+            'current_fuel_percent': current_fuel_percent,
+        }
+
+        if vehicle.get('latest_parking') is not None and vehicle.get('latest_parking', {}).get('id') is not None:
+            gbfs_vehicle['station_id'] = vehicle.get('latest_parking', {}).get('id')
+        else:
+            logger.info('Vehicle %s has no station (is in use), will be removed from feed', vehicle_id)
+            return  # ignore vehicle without station
+
+        if vehicle.get('cruising_range') is not None and vehicle['cruising_range'].get('value'):
+            gbfs_vehicle['current_range_meters'] = vehicle['cruising_range']['value']['cents'] * 1000
+
+        # Links seems not to work currently, so we don't generate them
+        # rental_uri = 'https://go.moqo.de/deeplink/createBooking?teamId={}&carId={}'.format(self.team_id, vehicle_id)
+        # gbfs_vehicle['rental_uris'] = {
+        #    'ios': rental_uri,
+        #    'android': rental_uri,
+        #    #'web': web_rental_uri
+        # }
+
+        vehicles[vehicle_id] = gbfs_vehicle
+
+    @classmethod
+    def _extract_vehicle_type(cls, vehicle_types: dict[str, Any], vehicle: dict[str, Any]) -> str:
+        vehicle_model = vehicle['car_model_name']
+        id = vehicle_model.replace(' ', '_').lower()
+        gbfs_make, gbfs_model = vehicle_model.split(' ')[0], ' '.join(vehicle_model.split(' ')[1:])
+        form_factor = cls._map_car_type(vehicle['vehicle_type'])
+        if not vehicle_types.get(id):
+            vehicle_types[id] = {
+                'vehicle_type_id': id,
+                'form_factor': form_factor,
+                'propulsion_type': cls._map_fuel_type(vehicle['fuel_type']),
+                'max_range_meters': cls.DEFAULT_MAX_RANGE_METERS,
+                'name': vehicle_model,
+                'make': gbfs_make,
+                'model': gbfs_model,
+                'return_type': 'roundtrip',
+                'default_pricing_plan_id': cls._default_pricing_plan_id(vehicle['car_type']),
+            }
+        return id
+
+    @staticmethod
+    def _map_car_type(car_type: str) -> str:
+        if car_type in {'bike'}:
+            return 'bicycle'
+        if car_type in {
+            'car',
+            'compact_car',
+            'convertible',
+            'demo_car',
+            'limousine',
+            'mini_car',
+            'small_family_car',
+            'sportscar',
+            'vintage_car',
+            'station_wagon',
+            'suv',
+            'transporter',
+            'recreational_vehicle',
+            'van',
+        }:
+            return 'car'
+        if car_type in {'scooter'}:
+            return 'moped'
+        if car_type in {'kick_scooter'}:
+            return 'scooter'
+        if car_type in {'other'}:
+            return 'other'
+
+        logger.warning('Unknown car_type: %s', car_type)
+        return 'other'
+
+    @classmethod
+    def _map_fuel_type(cls, fuel_type: str) -> str:
+        if fuel_type in cls.FUEL_TYPE_MAPPING:
+            return cls.FUEL_TYPE_MAPPING[fuel_type]
+
+        logger.warning('Unknown fuel_type: %s, will use combustion', fuel_type)
+        return 'combustion'
+
+    @staticmethod
+    def _default_pricing_plan_id(car_type: str) -> str:
+        return 'tarif'
+
+
+class StadtwerkTauberfrankenProvider(MoqoProvider):
+    pass

--- a/x2gbfs/util.py
+++ b/x2gbfs/util.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timezone
+from typing import Any, Dict, Generator, Optional, Tuple
+
+import requests
 
 
 def timestamp_to_isoformat(utctimestamp: datetime):
@@ -9,3 +12,15 @@ def timestamp_to_isoformat(utctimestamp: datetime):
     See also https://github.com/MobilityData/gbfs-json-schema/issues/95
     """
     return utctimestamp.isoformat().replace('+00:00', 'Z')
+
+
+def get(
+    url: str,
+    params: Optional[dict[str, str]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: int = 5,
+    user_agent: str = 'x2gbfs +https://github.com/mobidata-bw/',
+):
+    request_headers = dict(headers) if headers is not None else {}
+    request_headers['User-Agent'] = user_agent
+    return requests.get(url, headers=request_headers, timeout=timeout, params=params)

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -16,6 +16,7 @@ from x2gbfs.providers import (
     ExampleProvider,
     FleetsterAPI,
     LastenVeloFreiburgProvider,
+    StadtwerkTauberfrankenProvider,
     VoiRaumobil,
 )
 
@@ -44,6 +45,8 @@ def build_extractor(provider: str, feed_config: Dict[str, Any]) -> BaseProvider:
         return VoiRaumobil(api_url, api_user, api_password)
     if provider in ['my-e-car'] or provider.startswith('stadtmobil_'):
         return CantamenIXSIProvider(feed_config)
+    if provider in ['stadtwerk_tauberfranken']:
+        return StadtwerkTauberfrankenProvider(feed_config)
 
     raise ValueError(f'Unknown config {provider}')
 


### PR DESCRIPTION
This PR adds an initial implementation for `stadtwerke-tauberfranken`, which uses MOQO as API provider.

Still to do later on, if more information is provided regarding the API:

* max/~current_range~ information
* deeplinks
* home station for currently unavailable vehicles