### PR TITLE
Convert custom _feed_notice to standard system_alerts

### DIFF
--- a/config/my-e-car.json
+++ b/config/my-e-car.json
@@ -1,5 +1,13 @@
 {
     "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
         "pricing_plans": [
             {
                 "currency": "EUR",
@@ -309,9 +317,8 @@
             "terms_last_updated": "2022-02-15",
             "terms_url": "https://www.my-e-car.de/agb/",
             "timezone": "Europe/Berlin",
-            "url": "https://www.my-e-car.de/",
-	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
-        }
+            "url": "https://www.my-e-car.de/"
+	    }
     },
     "system_id": "10024",
     "provider_id": 84,

--- a/config/stadtmobil_stuttgart.json
+++ b/config/stadtmobil_stuttgart.json
@@ -1,5 +1,13 @@
 {
     "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
         "pricing_plans": [
             {
                 "currency": "EUR",
@@ -221,8 +229,7 @@
             "terms_last_updated": "2020-02-01",
             "terms_url": "https://stuttgart.stadtmobil.de/agb/",
             "timezone": "Europe/Berlin",
-            "url": "https://stuttgart.stadtmobil.de/",
-	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
+            "url": "https://stuttgart.stadtmobil.de/"
         }
     },
     "system_id": "10024",

--- a/config/stadtmobil_suedbaden.json
+++ b/config/stadtmobil_suedbaden.json
@@ -1,5 +1,13 @@
 {
     "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
         "pricing_plans": [
             {
                 "currency": "EUR",
@@ -275,8 +283,7 @@
             "terms_last_updated": "2021-02-01",
             "terms_url": "https://www.stadtmobil-suedbaden.de/agb/",
             "timezone": "Europe/Berlin",
-            "url": "https://www.stadtmobil-suedbaden.de/",
-	    "_feed_notice": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar."
+            "url": "https://www.stadtmobil-suedbaden.de/"
         }
     },
     "system_id": "10024",

--- a/x2gbfs/gbfs/gbfs_writer.py
+++ b/x2gbfs/gbfs/gbfs_writer.py
@@ -34,6 +34,7 @@ class GbfsWriter:
     ) -> None:
         base_url = base_url or config['publication_base_url']
         pricing_plans = config['feed_data'].get('pricing_plans')
+        alerts = config['feed_data'].get('alerts')
         system_information = copy.deepcopy(config['feed_data']['system_information'])
         feed_language = system_information['language']
 
@@ -64,4 +65,7 @@ class GbfsWriter:
         if pricing_plans:
             feeds.append('system_pricing_plans')
             self.write_gbfs_file(destFolder + '/system_pricing_plans.json', {'plans': pricing_plans}, timestamp, ttl)
+        if alerts:
+            feeds.append('system_alerts')
+            self.write_gbfs_file(destFolder + '/system_alerts.json', {'alerts': alerts}, timestamp, ttl)
         self.write_gbfs_file(destFolder + '/gbfs.json', self.gbfs_data(feed_language, base_url, feeds), timestamp, ttl)


### PR DESCRIPTION
This PR converts _feed_notice to standard system_alerts.

For cantamen feeds, instead of a custom `system_information._feed_notice` information, an alert of type `other` and ID `mobidata_1` is generated.

This has the advantage, that it is conform to the standard and potentially even customer facing.