### PR TITLE
Add date-based container tag

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -27,12 +27,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
+    - name: set date-based tag
+      run: |
+        echo "DATE_TAG=$(date +%Y-%m-%dT%H-%M)" >> $GITHUB_ENV
+        
     - name: build and push Docker image
       uses: docker/build-push-action@v5
       with:
         push: true
         tags: |
           ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ env.DATE_TAG }}
         platforms: linux/amd64,linux/arm64
         # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
         cache-from: type=gha


### PR DESCRIPTION
Just like in many other repos, I'm adding date-based container tags. They look like `2024-02-24T21-05`

This is to help users to select a fixed version of the image rather than a moving target of `latest`.

Here is an example of what it looks like: https://github.com/leonardehrenfried/x2gbfs/pkgs/container/x2gbfs