### PR TITLE
Add vehicle_type_id normalization for moqo

### DIFF
--- a/x2gbfs/gbfs/base_provider.py
+++ b/x2gbfs/gbfs/base_provider.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any, Dict, Generator, Optional, Tuple
 
 logger = logging.getLogger('x2gbfs.base_provider')
@@ -74,3 +75,10 @@ class BaseProvider:
             'vehicle_types_available': [],
             'last_reported': last_reported,
         }
+
+    @staticmethod
+    def _normalize_id(id: str) -> str:
+        """
+        Normalizes the ID by restricting chars to A-Za-z_0-9. Whitespaces are converted to _.
+        """
+        return re.sub('[^A-Za-z_0-9]', '', id.lower().replace(' ', '_')).replace('__', '_')

--- a/x2gbfs/providers/deer.py
+++ b/x2gbfs/providers/deer.py
@@ -118,12 +118,6 @@ class Deer(BaseProvider):
         normalized_model = re.sub(r'(?i)e[ -]up!?', 'e-up!', normalized_model)
         return re.sub(r'(?i)e[ -]golf', 'e-Golf', normalized_model)
 
-    def normalize_id(self, id: str) -> str:
-        """
-        Normalizes the ID by restricting chars to A-Za-z_0-9. Whitespaces are converted to _.
-        """
-        return re.sub('[^A-Za-z_0-9]', '', id.lower().replace(' ', '_')).replace('__', '_')
-
     def pricing_plan_id(self, vehicle: Dict) -> Optional[str]:
         """
         Maps deer's vehicle categories to pricing plans (provided viaa config).
@@ -186,7 +180,7 @@ class Deer(BaseProvider):
         vehicle_id = str(fleetster_vehicle['_id'])
         normalized_brand = self._normalize_brand(fleetster_vehicle['brand'])
         normalized_model = self._normalize_model(fleetster_vehicle['model'])
-        vehicle_type_id = self.normalize_id(normalized_brand + '_' + normalized_model)
+        vehicle_type_id = self._normalize_id(normalized_brand + '_' + normalized_model)
 
         extended_properties = fleetster_vehicle['extended']['Properties']
         accessories = []

--- a/x2gbfs/providers/moqo.py
+++ b/x2gbfs/providers/moqo.py
@@ -190,7 +190,7 @@ class MoqoProvider(BaseProvider):
     @classmethod
     def _extract_vehicle_type(cls, vehicle_types: dict[str, Any], vehicle: dict[str, Any]) -> str:
         vehicle_model = vehicle['car_model_name']
-        id = vehicle_model.replace(' ', '_').lower()
+        id = cls._normalize_id(vehicle_model)
         gbfs_make, gbfs_model = vehicle_model.split(' ')[0], ' '.join(vehicle_model.split(' ')[1:])
         form_factor = cls._map_car_type(vehicle['vehicle_type'])
         if not vehicle_types.get(id):


### PR DESCRIPTION
This PR addresses current lamassu ID constraints, which are more restrictive than those of the GBFS feed spec. 

I.e., dots like in current vehicle_type `vw_id.3` will be removed. This addresses https://github.com/mobidata-bw/ipl-orchestration/issues/111. 

---

fixes https://github.com/mobidata-bw/ipl-orchestration/issues/111