### PR TITLE
fix: for deer, ignore inactive bookings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+The changelog lists most feature changes between each release. The list is automatically created
+based on merged pull requests. Search GitHub issues and pull requests for smaller issues.
+
+## Upcoming release (under development)
+
+- fix: for deer, ignore inactive bookings (fixes #132)

--- a/docs/mappings/deer_gbfs_2.3_mapping.md
+++ b/docs/mappings/deer_gbfs_2.3_mapping.md
@@ -166,7 +166,7 @@ GBFS Field | Mapping
 `bike_id` |  `vehicle['_id']`
 `lat` |  -
 `lon` |  -
-`is_reserved` | `False`, if bookings request does not return any booking having startDate < now < endDate for this vehicle, else true (see also `available_until`)
+`is_reserved` | `False`, if bookings request does not return any active booking having startDate < now < endDate for this vehicle, else true (see also `available_until`). An active booking is a booking which is not in any of the following states: canceled, rejected, keyreturned
 `is_disabled` | -
 `rental_uris` | None. fleetster/deer do not provide rental uris for now
 `vehicle_type_id` | normalized, lower cased `vehicle['brand']` + '_' + normalized, lower cased `vehicle['model']`
@@ -177,7 +177,7 @@ GBFS Field | Mapping
 `home_station_id` | -
 `pricing_plan_id` | -
 `vehicle_equipment` | `winter_tires` if `extended.Properties.winterTires`
-`available_until` | `/bookings?endDate%5B%24gte%5D={now}Z` returns all bookings ending in the future. If there is no booking for this vehicle (`vehicleId == booking['vehicleId']`) which has already started (`bookings['startDate'] < now`) ), available_until is the earliest booking's `bookings['startDate']`. Unset else.
+`available_until` | `/bookings?endDate%5B%24gte%5D={now}Z` returns all bookings ending in the future. If there is no active booking (see above for a definition of an active booking) for this vehicle (`vehicleId == booking['vehicleId']`) which has already started (`bookings['startDate'] < now`) ), available_until is the earliest booking's `bookings['startDate']`. Unset else.
 
 
 ### system_hours.json

--- a/docs/mappings/deer_gbfs_2.3_mapping.md
+++ b/docs/mappings/deer_gbfs_2.3_mapping.md
@@ -166,7 +166,7 @@ GBFS Field | Mapping
 `bike_id` |  `vehicle['_id']`
 `lat` |  -
 `lon` |  -
-`is_reserved` | `False`, if bookings request does not return any active booking having startDate < now < endDate for this vehicle, else true (see also `available_until`). An active booking is a booking which is not in any of the following states: canceled, rejected, keyreturned
+`is_reserved` | `False`, if bookings request does not return any active booking having startDate < now < endDate for this vehicle, else `True` (see also `available_until`). An active booking is a booking which is not in any of the following states: `canceled`, `rejected`, `keyreturned`.
 `is_disabled` | -
 `rental_uris` | None. fleetster/deer do not provide rental uris for now
 `vehicle_type_id` | normalized, lower cased `vehicle['brand']` + '_' + normalized, lower cased `vehicle['model']`


### PR DESCRIPTION
This PR ignores inactive bookings, i.e. such in state canceled, rejected, keyreturned (see also https://github.com/mobidata-bw/ipl-orchestration/issues/132).
