### PR TITLE
fix: remove +- chars from cantamen vehicle type ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ based on merged pull requests. Search GitHub issues and pull requests for smalle
 ## Upcoming release (under development)
 - TBD
 
+## 2024-05-02
+- fix: remove plus and minus (-+) chars from cantamen vehicle type ids to workaround lamassu id restriction
+
 ## 2024-04-29
 - fix: for deer, ignore inactive bookings (fixes #132)
 - add new feed stadtmobil_karlsruhe (#97)

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -232,7 +232,7 @@ class CantamenIXSIProvider(BaseProvider):
         return 'cargo_bicycle' if bookee['Class'] == 'bike' else 'car'
 
     def _as_vehicle_type_id(self, vehicle_name: str) -> str:
-        return vehicle_name.lower().translate({ord(c): None for c in ',< ().äöüß/'})
+        return vehicle_name.lower().translate({ord(c): None for c in ',< ().äöüß/+-'})
 
     def _extract_vehicle_name(self, bookee_name: str) -> str:
         # Vehicles usually have their license plate (in parentheses) appended in their name.


### PR DESCRIPTION
This PR removes + and minus signs from vehicle_ids to work around a current Lamassu limitation.