### PR TITLE
Add deeplink for MOQO vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-The changelog lists most feature changes between each release. The list is automatically created
-based on merged pull requests. Search GitHub issues and pull requests for smaller issues.
+The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## Upcoming release (under development)
-- TBD
+
+## 2024-06-03
+- add deeplinks for MOQO based providers, i.e. `stadtwerk_tauberfranken`
 
 ## 2024-05-02
 - fix: remove plus and minus (-+) chars from cantamen vehicle type ids to workaround lamassu id restriction

--- a/x2gbfs/providers/moqo.py
+++ b/x2gbfs/providers/moqo.py
@@ -158,6 +158,9 @@ class MoqoProvider(BaseProvider):
             vehicle['fuel_level'] / 100.0 if 'fuel_level' in vehicle else self.DEFAULT_CURRENT_FUEL_PERCENT
         )
         current_range_meters = vehicle_types[vehicle_type_id]['max_range_meters'] * current_fuel_percent
+
+        deeplink = f'https://go.moqo.de/deeplink/createBooking?teamId={self.team_id}&carId={vehicle_id}'
+
         gbfs_vehicle = {
             'bike_id': str(vehicle_id),
             'is_reserved': vehicle['available'] is not True,
@@ -166,6 +169,11 @@ class MoqoProvider(BaseProvider):
             'license_plate': vehicle['license'].split('|')[0].strip(),
             'current_range_meters': current_range_meters,
             'current_fuel_percent': current_fuel_percent,
+            'rental_uris': {
+                'web': deeplink,
+                'ios': deeplink,
+                'android': deeplink,
+            },
         }
 
         if vehicle.get('latest_parking') is not None and vehicle.get('latest_parking', {}).get('id') is not None:


### PR DESCRIPTION
This PR adds deeplinks to MOQO vehicles.

Note that following these links will display an ugly warning in the MOQO app unless the user explicitly registered with Stadtwerk Tauberfranken in the MOQO app (which currently will involve a one-time fee of 4,90€):

<img width="432" alt="image" src="https://github.com/mobidata-bw/x2gbfs/assets/2187389/608a8711-caa9-4085-8e5e-7933bfaee071">

I suggest to approach MOQO, if this could not be changed to a somewhat user-friendlier behavior.

