### PR TITLE
ignore bookees with pool name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## [Unreleased]
-- add Cantamen provider stadtmobil_rhein-neckar
+- add Cantamen provider stadtmobil_rhein-neckar, ignore its bookees having a pool name instead of a vehicle name
 - stabilize cantamen providers against attributes data error
 
 ## 2024-07-03

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -338,6 +338,10 @@ class CantamenIXSIProvider(BaseProvider):
         for bookee in self._all_bookees():
             bookee_id = bookee.get('ID')
             try:
+                name = bookee['Name']['Text']
+                if 'Pool' in name:  # No make and model in name
+                    logger.info(f'Bookee {bookee_id} has Pool name "{name}" and will be ignored')
+                    continue
                 vehicle_type = self._extract_vehicle_type(bookee)
                 gbfs_vehicle = self._extract_vehicle(
                     bookee, vehicle_type['vehicle_type_id'], vehicle_type['max_range_meters']


### PR DESCRIPTION
stadtmobil_rhein-neckar uses these pool names, but there are few pool names at other providers.
We cannot derive the brand name or model name of a car from these pool names, so they shall be ignored.