### PR TITLE
stadtmobil: fix vehicle_types_id and num_bikes_available

### DIFF
--- a/x2gbfs/gbfs/gbfs_transformer.py
+++ b/x2gbfs/gbfs/gbfs_transformer.py
@@ -75,6 +75,10 @@ class GbfsTransformer:
                 self._update_station_availability_status(vehicle_types_per_station[station_id], status_map[station_id])
             else:
                 status_map[station_id]['vehicle_types_available'] = []
+                if 'num_bikes_available' not in status_map[station_id]:
+                    # num_bikes_available might have been set by provider,
+                    # so we only redefine if this is not the case
+                    status_map[station_id]['num_bikes_available'] = 0
 
     def _update_station_availability_status(
         self, vt_available: List[Dict[str, Any]], station_status: Dict[str, Any]

--- a/x2gbfs/providers/cantamen.py
+++ b/x2gbfs/providers/cantamen.py
@@ -238,7 +238,10 @@ class CantamenIXSIProvider(BaseProvider):
         return 'cargo_bicycle' if bookee['Class'] == 'bike' else 'car'
 
     def _as_vehicle_type_id(self, vehicle_name: str) -> str:
-        return vehicle_name.lower().translate({ord(c): None for c in ',< ().äöüßé/+-'})
+        # returns the vehicle name as lowercased string, filtered to alpha-numeric characters only.
+        # (Restrictive filtering is required as consuming systems like lamassu do only support a subset
+        # of characters allowed by the GBFS spec.)
+        return re.sub('[^a-z0-9]+', '', vehicle_name.lower())
 
     def _extract_vehicle_name(self, bookee_name: str) -> str:
         # Vehicles usually have their license plate (in parentheses) appended in their name.


### PR DESCRIPTION
This PR fixes two issues with the new `stadtmobil_rhein-neckar` feed:

1) the `vehicle_type_id` still contained a colon, which currently is not supported by Lamassu. Instead of adding yet another character to be filtered, we now remove all but lowercase characters.
2) In case a station has no associated vehicle_type at all, `num_bikes_available` was not set. Now, if the station_status does not declare `num_bikes_available`, it is set to `0` in this case