### PR TITLE
fix: flinkster returns currently availableRentalObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ The following command demonstrates how to run x2gbfs in a Docker container which
 ```sh
 docker build -t x2gbfs .
 # For dynamic feeds, update every 60 seconds (-i 60)
-docker run --rm -v $PWD/out:/app/out --env-file .env x2gbfs -p deer,voi-raumobil,lastenvelo_fr -b 'file:out' -i 60
+docker run --rm -v $PWD/out:/app/out --env-file .env x2gbfs -p deer,voi-raumobil,lastenvelo_fr,flinkster -b 'file:out' -i 60
 # For static feeds, an update every hour (3600 seconds) should be sufficient (-i 3600)
-docker run --rm -v $PWD/out:/app/out --env-file .env x2gbfs -p my-e-car,stadmobil_suedbaden,flinkster -b 'file:out' -i 3600
+docker run --rm -v $PWD/out:/app/out --env-file .env x2gbfs -p my-e-car,stadmobil_suedbaden -b 'file:out' -i 3600
 
 ```
 

--- a/config/flinkster.json
+++ b/config/flinkster.json
@@ -1,13 +1,5 @@
 {
     "feed_data": {
-        "alerts": [
-           {
-            "alert_id": "mobidatabw_1",
-                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
-                "summary": "Keine Echtzeitdaten",
-                "type": "other"
-            }
-        ],
         "pricing_plans": [
             {
                 "currency": "EUR",

--- a/docs/mappings/flinkster_gbfs_2.3_mapping.md
+++ b/docs/mappings/flinkster_gbfs_2.3_mapping.md
@@ -146,7 +146,7 @@ GBFS Field | Mapping
 
 ### free_bike_status.json
 
-Returns all vehicles of `/availableRentalObjects` endpoint.
+Returns all (currently available) vehicles of `/availableRentalObjects` endpoint.
 
 #### Field Mappings
 


### PR DESCRIPTION
This PR removes the "static vehicles only" alert and updates documentation accordingly.

Background: the `availableRentalObjects` endpoint only returns currently available objects.