### PR TITLE
Log timeout as error not exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## [Unreleased]
+- log timeout errors as error without stacktrace
+
+## 2024-09-05
 - add Flinkster provider
 
 ## 2024-07-23

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -65,6 +65,9 @@ def main(providers: List[str], output_dir: str, base_url: str, interval: int = 0
         for provider in providers:
             try:
                 generate_feed_for(provider, output_dir, base_url)
+            except TimeoutError:
+                logger.error(f'Generating feed for {provider} failed due to timeout error!')
+                error_occured = True
             except Exception:
                 logger.exception(f'Generating feed for {provider} failed!')
                 error_occured = True


### PR DESCRIPTION
This PR logs timeout errors as one line error without a stacktrace. 