### PR TITLE
add provider teilauto_neckar-alb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog lists most feature changes between each release. Search GitHub iss
 
 ## [Unreleased]
 - add Cantamen provider teilneckar_neckar-alb
-- 
+
 ## 2024-09-10
 - add Flinkster provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## [Unreleased]
+- add Cantamen provider teilneckar_neckar-alb
+- 
+## 2024-09-10
 - add Flinkster provider
 
 ## 2024-07-23

--- a/config/teilauto_neckar-alb.json
+++ b/config/teilauto_neckar-alb.json
@@ -1,0 +1,134 @@
+{
+    "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
+        "pricing_plans": [
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif XXS",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 1.65 }, { "start": 780, "interval": 60, "rate": 0.80 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.37 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.33 }, { "start": 501, "interval": 1,"rate": 0.28 } ],
+                "plan_id": "micro_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif XS",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 1.85 }, { "start": 780, "interval": 60, "rate": 0.90 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.39 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.35 }, { "start": 501, "interval": 1,"rate": 0.30 } ],
+                "plan_id": "mini_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif S",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.05 }, { "start": 780, "interval": 60, "rate": 1.00 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.42 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.38 }, { "start": 501, "interval": 1,"rate": 0.32 } ],
+                "plan_id": "small_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif M",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.15 }, { "start": 780, "interval": 60, "rate": 1.05 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.43 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.40 }, { "start": 501, "interval": 1,"rate": 0.33 } ],
+                "plan_id": "medium_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif L",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.35 }, { "start": 780, "interval": 60, "rate": 1.15 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.45 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.41 }, { "start": 501, "interval": 1,"rate": 0.35 } ],
+                "plan_id": "large_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif XL",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.55 }, { "start": 780, "interval": 60, "rate": 1.25 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.47 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.43 }, { "start": 501, "interval": 1,"rate": 0.37 } ],
+                "plan_id": "van_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tarif Clever. Für jede Buchung setzen sich die Nutzungskosten zusammen aus Zeittarif + Kilometertarif.",
+                "is_taxable": false,
+                "name": "Tarif XXL",
+                "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 3.85 }, { "start": 780, "interval": 60, "rate": 1.55 } ],
+                "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.57 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.51 }, { "start": 501, "interval": 1,"rate": 0.46 } ],
+                "plan_id": "transporter_hour",
+                "price": 0,
+                "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
+            }
+        ],
+        "system_information": {
+            "email": "info@teilauto-neckar-alb.de",
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de",
+            "license_url": "https://www.govdata.de/dl-de/by-2-0",
+            "license_id": "DL-DE-BY-2.0",
+            "attribution_organization_name": "teilAuto Neckar-Alb eG",
+            "attribution_url": "https://www.teilauto-neckar-alb.de/",
+            "name": "teilAuto Neckar-Alb",
+            "operator": "teilAuto Neckar-Alb eG",
+            "phone_number": "+49 (0)7071 360306",
+            "privacy_url": "https://www.teilauto-neckar-alb.de/datenschutz",
+            "purchase_url": "https://www.teilauto-neckar-alb.de/registrieren",
+            "rental_apps": {
+                "android": {
+                    "discovery_uri": "cantamen-interapp-csd://add_booking",
+                    "store_uri": "https://play.google.com/store/apps/details?id=de.cantamen.carsharing.deutschland"
+                },
+                "ios": {
+                    "discovery_uri": "cantamen-interapp-csd://add_booking",
+                    "store_uri": "https://apps.apple.com/de/app/carsharing-deutschland/id1075669223"
+                }
+            },
+            "system_id": "teilauto_neckar-alb",
+            "terms_last_updated": "2021-07-21",
+            "terms_url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/AGB.pdf",
+            "timezone": "Europe/Berlin",
+            "url": "https://www.teilauto-neckar-alb.de/"
+        }
+    },
+    "system_id": "10024",
+    "provider_id": 19,
+    "url_templates": {
+        "station": {
+            "android": "cantamen-interapp-csd://add_booking?openPlace={placeId}",
+            "ios": "cantamen-interapp-csd://add_booking?openPlace={placeId}",
+            "web": "https://ewi3.cantamen.de/?openPlace={placeId}"
+        },
+        "vehicle": {
+            "android": "cantamen-interapp-csd://add_booking?openBookee={bookeeId}",
+            "ios": "cantamen-interapp-csd://add_booking?openBookee={bookeeId}",
+            "web": "https://ewi3.cantamen.de/?openBookee={bookeeId}"
+        }
+    }
+}

--- a/config/teilauto_neckar-alb.json
+++ b/config/teilauto_neckar-alb.json
@@ -16,7 +16,7 @@
                 "name": "Tarif XXS",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 1.65 }, { "start": 780, "interval": 60, "rate": 0.80 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.37 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.33 }, { "start": 501, "interval": 1,"rate": 0.28 } ],
-                "plan_id": "micro_hour",
+                "plan_id": "micro_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -27,7 +27,7 @@
                 "name": "Tarif XS",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 1.85 }, { "start": 780, "interval": 60, "rate": 0.90 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.39 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.35 }, { "start": 501, "interval": 1,"rate": 0.30 } ],
-                "plan_id": "mini_hour",
+                "plan_id": "mini_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -38,7 +38,7 @@
                 "name": "Tarif S",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.05 }, { "start": 780, "interval": 60, "rate": 1.00 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.42 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.38 }, { "start": 501, "interval": 1,"rate": 0.32 } ],
-                "plan_id": "small_hour",
+                "plan_id": "small_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -49,7 +49,7 @@
                 "name": "Tarif M",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.15 }, { "start": 780, "interval": 60, "rate": 1.05 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.43 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.40 }, { "start": 501, "interval": 1,"rate": 0.33 } ],
-                "plan_id": "medium_hour",
+                "plan_id": "medium_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -60,7 +60,7 @@
                 "name": "Tarif L",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.35 }, { "start": 780, "interval": 60, "rate": 1.15 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.45 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.41 }, { "start": 501, "interval": 1,"rate": 0.35 } ],
-                "plan_id": "large_hour",
+                "plan_id": "large_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -71,7 +71,7 @@
                 "name": "Tarif XL",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 2.55 }, { "start": 780, "interval": 60, "rate": 1.25 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.47 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.43 }, { "start": 501, "interval": 1,"rate": 0.37 } ],
-                "plan_id": "van_hour",
+                "plan_id": "van_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             },
@@ -82,7 +82,7 @@
                 "name": "Tarif XXL",
                 "per_min_pricing": [ { "start": 0, "end": 720, "interval": 60, "rate": 3.85 }, { "start": 780, "interval": 60, "rate": 1.55 } ],
                 "per_km_pricing": [ { "start": 0, "end": 100, "interval": 1, "rate": 0.57 }, { "start": 101, "end": 500, "interval": 1, "rate": 0.51 }, { "start": 501, "interval": 1,"rate": 0.46 } ],
-                "plan_id": "transporter_hour",
+                "plan_id": "transporter_hour_daytime",
                 "price": 0,
                 "url": "https://www.teilauto-neckar-alb.de/fileadmin/teilauto/dokumente/downloads/teilAuto_tarifordnung.pdf"
             }


### PR DESCRIPTION
The x2gbfs tests results in:
python3 -m x2gbfs.x2gbfs -p teilauto_neckar-alb -b 'file:out'
INFO:x2gbfs:Updated feeds for teilauto_neckar-alb

Where do I find the resulting gbfs files? They are not in /var/docker-unmanaged/ipl/var/gbfs/feeds on test-ipl