### PR TITLE
Feat: support different base url for protected feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## Upcoming release
+- add new option `protected` option (`boolean`, default is `False`), which can be configured per feed in the config section (e.g. `'x2gbfs: { "protected": True }`). If set, instead of x2gbfs parameter `baseUrl` the optional parameter `protectedBaseUrl` is used in gbfs.json`
 - make FREE2MOVE_BASE_URL configurable (must now be provided as env var for free2move providers)
 - round vehicle and station coords to at most six decimal places
 - fix: `free2move_stuttgart` pricing plan, color naming, range and fuel level issues

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ To generate a GBFS feed for a Free2move location, you need to provide the follow
 
 Besides this, a CACHE_DIR env variable must be provided, which is used to store the last retrieved vehicles information, so only delta updates need to be requested.
 
+Note that Free2move is a feed that contains GDPR relevant vehicle
+information (the vehicle Id of free floating vehicles is not rotated by
+free2move after rentals). This feed should not be made publicly
+available.
+For this reason, property `x2gbfs/protected` is set to `true`. When
+`x2gbfs` is started with param  `--protectedBaseUrl` (shorthand `-r`),
+this base URL is used in gbfs.json.
+
 For details, see the [mapping documentation](./docs/mappings/free2move_gbfs_2.3_mapping.md).
 
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ x2gbfs is a library, which generates GBFS feed's from various providers.
 
 Currently supported providers:
 
-* deer (via it's fleetster API, provider id: `deer`)
-* VOI Karlsruhe (via Raumobil API, provider id: `voi-raumobil`)
-* Stadtmobil Südbaden (via Cantamen IXSI API, provider id: `stadtmobil_suedbaden`)
-* my-e-car (via Cantamen IXSI API, provider id: `my-e-car`)
+* deer (via it's fleetster API)
+* VOI Karlsruhe (via Raumobil API)
+* various Stadtmobil/Teilauto providers (via Cantamen IXSI API)
+* various MOQO based providers (e.g. Stadtwerke Tauberfranken)
+* DB Flinkster
+* Free2move
+* Cambio Aachen (via Cambio API)
 * Lastenvelo Freiburg (via custom CSV, provider id: `lastenvelo_fr`)
 * NOI OpenDataHub (provider id: `noi`)
 
-To generate a feed for e.g. deer network, switch to the `x2gbfs` project basee dir and execute
+To generate a feed for e.g. deer network, switch to the `x2gbfs` project base dir and execute
 
 ```sh
 DEER_API_URL=URL DEER_USER=USER DEER_PASSWORD=PASSWORD python -m x2gbfs.x2gbfs -p deer -b 'file:out'
@@ -33,15 +36,8 @@ be provided via config/<provider>.json and needs to be updated when that informa
 
 ## Available providers
 
-Currently, a couple of providers are supported:
+Currently, more than 20 providers are supported. For details, see the current state in folder [config/](https://github.com/mobidata-bw/x2gbfs/tree/main/config)
 
-* deer, which uses Fleetster as backend provider,
-* Lastenvelo Freiburg
-* VOI Karlsruhe via backend provider Raumobil
-* Stadtwerk Tauberfranken via backend provider MOQO
-* Carsharing Südtirol via Nature Of Innovation (NOI)'s OpenDataHub
-* Flinkster via db-connect API,
-* and my-e-car, stadtmobil Südbaden and stadtmobil Stuttgart via backend provider Cantamen/IXSI.
 
 ### deer (Fleetster)
 
@@ -80,7 +76,9 @@ copy the config/cambio_aachen config and adapt accordingly.
 
 Note that the pricing plans don't reflect the various available tarifs.
 
-Note also, that Cambio asks users to only request their information once per 24 hours.
+Note also, that Cambio asks users to only request their information
+once per 24 hours. To reflect this in the generated GBFS, it uses a
+[`ttl` of `86400`](https://github.com/mobidata-bw/x2gbfs/blob/main/config/cambio_aachen.json#L89-91) which deviates from x2gbfs' default value (60).
 
 For details, see the [mapping documentation](./docs/mappings/cambio_gbfs_2.3_mapping.md).
 
@@ -105,6 +103,7 @@ To generate the Stadtwerk Tauberfranken GBFS feed, you need to provide the follo
 
 * `MOQO_API_TOKEN=<MOQO Token>`
 
+For details, see the [mapping documentation](./docs/mappings/moqo_gbfs_2.3_mapping.md).
 
 ### Flinkster (DB-Connect)
 
@@ -112,6 +111,8 @@ To generate the Flinkster GBFS feed, you need to provide the following environme
 
 * `FLINKSTER_CLIENT_ID=<FLINKSTER_CLIENT_ID>`
 * `FLINKSTER_SECRET=<FLINKSTER_SECRET>`
+
+For details, see the [mapping documentation](./docs/mappings/flinkster_gbfs_2.3_mapping.md).
 
 ### Free2move
 

--- a/config/cambio_aachen.json
+++ b/config/cambio_aachen.json
@@ -86,5 +86,7 @@
     "provider-info": {
         "city_id": "AAC"
     },
-    "ttl": 86400
+    "x2gbfs": {
+        "ttl": 86400
+    }
 }

--- a/config/deer.json
+++ b/config/deer.json
@@ -85,6 +85,5 @@
             "timezone": "Europe/Berlin",
             "url": "https://www.deer-carsharing.de/"
         }
-    },
-    "publication_base_url": "https://data.mfdz.de/mobidata-bw/deer"
+    }
 }

--- a/config/free2move_stuttgart.json
+++ b/config/free2move_stuttgart.json
@@ -92,5 +92,8 @@
     "provider_data": {
         "location_alias": "stuttgart",
         "location_id": 18
+    },
+    "x2gbfs": {
+        "protected": true
     }
 }

--- a/config/lastenvelo_fr.json
+++ b/config/lastenvelo_fr.json
@@ -34,5 +34,7 @@
             "url": "https://www.lastenvelofreiburg.de/"
         }
     },
-    "ttl": 300
+    "x2gbfs": {
+        "ttl": 300
+    }
 }

--- a/config/voi-raumobil.json
+++ b/config/voi-raumobil.json
@@ -1,6 +1,6 @@
 {
     "feed_data": {
-	"pricing_plans": [
+        "pricing_plans": [
             {
                 "currency": "EUR",
                 "description": "1 EURO + 0,22 EURO/Minute.",
@@ -16,7 +16,7 @@
                 "plan_id": "basic",
                 "price": 1
             }
-	],
+        ],
         "system_information": {
             "email": "support@voiapp.io",
             "feed_contact_email": "mobidata-bw@nvbw.de",
@@ -26,7 +26,6 @@
             "system_id": "voi_karlsruhe",
             "timezone": "Europe/Berlin"
         }
-    },
-    "publication_base_url": "https://data.mfdz.de/mobidata-bw/voi"
+    }
 }
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ types-requests==2.32.0.20241016
 types-urllib3==1.26.25.14
 types-xmltodict==0.13.0.3
 
-ruff~=0.8.1
-black~=24.8.0
-mypy~=1.11.2
+ruff~=0.9.6
+black~=25.1.0
+mypy~=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests~=2.32.3
 python-decouple~=3.8
-websockets~=14.1
+websockets~=15.0
 xmltodict~=0.13
 unidecode~=1.3

--- a/x2gbfs/providers/free2move.py
+++ b/x2gbfs/providers/free2move.py
@@ -212,6 +212,7 @@ class Free2moveProvider(BaseProvider):
     # Note: these are deduced from https://www.free2move.com/de/de/car-sharing/stuttgart/
     # and may change from time to time and should be regularly checked.
     BUILD_SERIES_PRICING_PLAN_MAPPING = {
+        'FIAT_500': 'mini',
         'FIAT_500_BEV': 'mini',
         'OPEL_ASTRA': 'standard',
         'OPEL_CORSA': 'standard',
@@ -272,6 +273,7 @@ class Free2moveProvider(BaseProvider):
         # colors currently used in Stuttgart
         '268U': 'weiß',
         'P0WP': 'weiß',
+        '650U': 'weiß',
         '601U': 'schwarz',
         '205U': 'grau',  # mineralgrey
         'M0V9': 'schwarz',  # carbon black

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -28,6 +28,15 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
 logger = logging.getLogger('x2gbfs')
 
+X2GBFS_DEFAULT_CONFIG = {
+    # Default ttl for every gbfs file.
+    # Might be overriden for static feeds that are expected to change less frequently.
+    'ttl': 60,
+    # Is this feed for protected publication? If true, param `protectedBaseUrl`
+    # must be provided on startup and will be used as feed base url instead of `baseUrl`
+    'protected': False,
+}
+
 
 def build_extractor(provider: str, feed_config: Dict[str, Any]) -> BaseProvider:
     if provider == 'example':
@@ -72,16 +81,20 @@ def build_extractor(provider: str, feed_config: Dict[str, Any]) -> BaseProvider:
     raise ValueError(f'Unknown config {provider}')
 
 
-def main(providers: List[str], output_dir: str, base_url: str, interval: int = 0) -> None:
+def main(
+    providers: List[str], output_dir: str, base_url: str, protected_base_url: str | None, interval: int = 0
+) -> None:
     should_loop_infinetly = interval > 0
     error_occured = False
 
     while True:
         for provider in providers:
             try:
-                generate_feed_for(provider, output_dir, base_url)
+                generate_feed_for(provider, output_dir, base_url, protected_base_url)
             except HTTPError as err:
-                logger.error(f'Generating feed for {provider} failed due to HTTP error {err.response.text}')
+                logger.error(
+                    f'Generating feed for {provider} failed due to HTTP error {err.response.status_code} for url {err.request.url}'
+                )
                 error_occured = True
             except TimeoutError:
                 logger.error(f'Generating feed for {provider} failed due to timeout error!')
@@ -97,7 +110,15 @@ def main(providers: List[str], output_dir: str, base_url: str, interval: int = 0
             exit(error_occured)
 
 
-def generate_feed_for(provider: str, output_dir: str, base_url: str) -> None:
+def get_x2gbfs_config_value(feed_config, key):
+    """
+    Returns x2gbfs config value, which can be overritten per feed via a x2gbfs section
+    in feed config.
+    """
+    return feed_config.get('x2gbfs', {}).get(key, X2GBFS_DEFAULT_CONFIG.get(key))
+
+
+def generate_feed_for(provider: str, output_dir: str, base_url: str, protected_base_url: str | None) -> None:
     with open(f'config/{provider}.json') as config_file:
         feed_config = json.load(config_file)
 
@@ -107,6 +128,17 @@ def generate_feed_for(provider: str, output_dir: str, base_url: str) -> None:
     (info, status, vehicle_types, vehicles, geofencing_zones, last_reported) = transformer.load_stations_and_vehicles(
         extractor
     )
+
+    is_feed_protected = get_x2gbfs_config_value(feed_config, 'protected')
+    if is_feed_protected:
+        if protected_base_url is None:
+            logger.warning(f'Feed {provider} is declared protected, but protectedBaseUrl is undefined, using baseUrl')
+            feed_base_url = f'{base_url}/{provider}'
+        else:
+            feed_base_url = f'{protected_base_url}/{provider}'
+    else:
+        feed_base_url = f'{base_url}/{provider}'
+
     GbfsWriter().write_gbfs_feed(
         feed_config,
         f'{output_dir}/{provider}',
@@ -115,9 +147,9 @@ def generate_feed_for(provider: str, output_dir: str, base_url: str) -> None:
         vehicle_types,
         vehicles,
         geofencing_zones,
-        f'{base_url}/{provider}',
+        feed_base_url,
         last_reported,
-        ttl=feed_config.get('ttl', 60),
+        ttl=get_x2gbfs_config_value(feed_config, 'ttl'),
     )
     logger.info(f'Updated feeds for {provider}')
 
@@ -128,7 +160,18 @@ if __name__ == '__main__':
         '-o', '--outputDir', help='output directory the transformed files are written to', default='out'
     )
     parser.add_argument('-p', '--providers', required=True, help='service provider(s), comma-separated')
-    parser.add_argument('-b', '--baseUrl', required=True, help='baseUrl this/these feed(s) will be published under')
+    parser.add_argument(
+        '-b',
+        '--baseUrl',
+        required=True,
+        help='baseUrl this/these feed(s) will be published under (if not flagged protected in config)',
+    )
+    parser.add_argument(
+        '-r',
+        '--protectedBaseUrl',
+        required=False,
+        help='protected baseUrl this/these feed(s) will be published under, if config declares `x2gbfs/protected: true`',
+    )
     parser.add_argument(
         '-i',
         '--interval',
@@ -140,4 +183,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    main(args.providers.split(','), args.outputDir, args.baseUrl, args.interval)
+    main(args.providers.split(','), args.outputDir, args.baseUrl, args.protectedBaseUrl, args.interval)


### PR DESCRIPTION
This PR adds a new CLI parameter `--protectedBaseUrl` which is used for `gbfs.json` URLs, when a feed config declares a feed protected via a section

```json
{
  "x2gbfs": {
    "protected": true
  }
}
```

The optional, formerly top level feed config parameter `ttl` has been moved to this new `x2gbfs` section as well.

Besides this, some dependency versions are bumped, README improved and outdated feed config parameters removed.  

