### PR TITLE
Feature: Support Herrenberg's GBFS light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog lists most feature changes between each release. Search GitHub iss
 
 ## Upcoming release
 - feat: add support for "GBFS-Light", a single file json format suggested by the city of Herrenberg to provide static bikesharing data via a single JSON file.
+- providers: config for new systems `herrenberg_lastenrad`, `herrenberg_alf`, `herrenberg_guelf`, `herrenberg_fare`.
 - refactor: `pricing_plan`, `system_information` and `alerts` data retrieval moved form `GbfsWriter` to Provider, so these can return dynamic information. Per default, these feeds are still retrieved from the feed config.
 
 ## 2025-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
+## Upcoming release
+- feat: add support for "GBFS-Light", a single file json format suggested by the city of Herrenberg to provide static bikesharing data via a single JSON file.
+- refactor: `pricing_plan`, `system_information` and `alerts` data retrieval moved form `GbfsWriter` to Provider, so these can return dynamic information. Per default, these feeds are still retrieved from the feed config.
+
 ## 2025-04-08
 - update gruene-flotte_freiburg pricing
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Currently supported providers:
 * VOI Karlsruhe (via Raumobil API)
 * various Stadtmobil/Teilauto providers (via Cantamen IXSI API)
 * various MOQO based providers (e.g. Stadtwerke Tauberfranken)
+* various cargo bike systems of Herrenberg city, provided in a static, lightweight json close to GBFS ("gbfs-light")
 * DB Flinkster
 * Free2move
 * Cambio Aachen (via Cambio API)
 * Lastenvelo Freiburg (via custom CSV, provider id: `lastenvelo_fr`)
 * NOI OpenDataHub (provider id: `noi`)
+
 
 To generate a feed for e.g. deer network, switch to the `x2gbfs` project base dir and execute
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently supported providers:
 * VOI Karlsruhe (via Raumobil API)
 * various Stadtmobil/Teilauto providers (via Cantamen IXSI API)
 * various MOQO based providers (e.g. Stadtwerke Tauberfranken)
-* various cargo bike systems of Herrenberg city, provided in a static, lightweight json close to GBFS ("gbfs-light")
+* various cargo bike systems of Herrenberg city, provided in a static, lightweight json close to GBFS ("[gbfs-light](https://oda-git-jens-ox-gbfs-light-jens-ochsenmeiers-projects.vercel.app/schema/gbfs-light)")
 * DB Flinkster
 * Free2move
 * Cambio Aachen (via Cambio API)

--- a/config/herrenberg_alf.json
+++ b/config/herrenberg_alf.json
@@ -1,0 +1,25 @@
+{
+    "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
+        "pricing_plans": [],
+        "system_information": {
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de"
+        }
+    },
+    "provider_data": {
+        "url": "https://www.munigrid.de/api/dataset/download?key=lastenraeder&org=hbg&distribution=gbfs",
+        "system_id": "herrenberg_alf"
+    },
+    "x2gbfs": {
+        "static": true,
+        "provider": "gbfs-light"
+    }
+}

--- a/config/herrenberg_fare.json
+++ b/config/herrenberg_fare.json
@@ -1,0 +1,25 @@
+{
+    "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
+        "pricing_plans": [],
+        "system_information": {
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de"
+        }
+    },
+    "provider_data": {
+        "url": "https://www.munigrid.de/api/dataset/download?key=lastenraeder&org=hbg&distribution=gbfs",
+        "system_id": "herrenberg_FaRe"
+    },
+    "x2gbfs": {
+        "static": true,
+        "provider": "gbfs-light"
+    }
+}

--- a/config/herrenberg_guelf.json
+++ b/config/herrenberg_guelf.json
@@ -1,0 +1,25 @@
+{
+    "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
+        "pricing_plans": [],
+        "system_information": {
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de"
+        }
+    },
+    "provider_data": {
+        "url": "https://www.munigrid.de/api/dataset/download?key=lastenraeder&org=hbg&distribution=gbfs",
+        "system_id": "herrenberg_guelf"
+    },
+    "x2gbfs": {
+        "static": true,
+        "provider": "gbfs-light"
+    }
+}

--- a/config/herrenberg_stadtrad.json
+++ b/config/herrenberg_stadtrad.json
@@ -1,0 +1,25 @@
+{
+    "feed_data": {
+        "alerts": [
+           {
+            "alert_id": "mobidatabw_1",
+                "description": "Keine Echtzeitdaten zum Buchungsstatus der Fahrzeuge. Verfügbarkeit ist im Buchungssystem des Anbieters sichtbar.",
+                "summary": "Keine Echtzeitdaten",
+                "type": "other"
+            }
+        ],
+        "pricing_plans": [],
+        "system_information": {
+            "feed_contact_email": "mobidata-bw@nvbw.de",
+            "language": "de"
+        }
+    },
+    "provider_data": {
+        "url": "https://www.munigrid.de/api/dataset/download?key=lastenraeder&org=hbg&distribution=gbfs",
+        "system_id": "herrenberg_stadtrad"
+    },
+    "x2gbfs": {
+        "static": true,
+        "provider": "gbfs-light"
+    }
+}

--- a/docs/mappings/gbfslight_gbfs_2.3_mapping.md
+++ b/docs/mappings/gbfslight_gbfs_2.3_mapping.md
@@ -1,0 +1,193 @@
+# GBFS-Light to GBFS Mapping
+
+This document maps "[GBFS-Light](https://oda-8059lnsdc-jens-ochsenmeiers-projects.vercel.app/schema/gbfs-light)" format intended for simple static feeds to GBFS.
+Credits to Jens Ochsenmeier for suggesting this simplyfied version, which can be
+generated from a simple CSV table easily maintainable by responsible parties.
+
+
+# Reference version
+
+This documentation refers to **[v2.3](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md)**.
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [General Information](#general-information)
+* [Open Issues or Questions](#open-issues-or-questions)
+* [Files](#files)
+    * [gbfs.json](#gbfsjson)
+    * [gbfs_versions.json](#gbfs_versionsjson) *(added in v1.1)*
+    * [system_information.json](#system_informationjson)
+    * [vehicle_types.json](#vehicle_typesjson) *(added in v2.1)*
+    * [station_information.json](#station_informationjson)
+    * [station_status.json](#station_statusjson)
+    * [free_bike_status.json](#free_bike_statusjson)
+    * [system_hours.json](#system_hoursjson)
+    * [system_calendar.json](#system_calendarjson)
+    * [system_regions.json](#system_regionsjson)
+    * [system_pricing_plans.json](#system_pricing_plansjson)
+    * [system_alerts.json](#system_alertsjson)
+    * [geofencing_zones.json](#geofencing_zonesjson) *(added in v2.1)*
+
+## Introduction
+
+This specification describes the mapping of "GBFS-Light" format to GBFS.
+
+
+## General Information
+
+This section gives a high level overview of the "GBFS-Light" format and the defined mapping to GBFS.
+
+The GBFS-Light endpoint returns a JSON file. It provides a `system` property which lists all available systems. For a single system entry, this mapping describes how it is mapped to a complete GBFS feed.
+
+## Files
+
+### gbfs.json
+
+Standard file, feed will be provided in feed language `de` only.
+
+### gbfs_versions.json
+
+Optional file, will not be provided. Only GBFS v2.3 supported.
+
+### system_information.json
+
+System information is provided via GBFS-Light and augmented by statically defined defaults from the feed_config (e.g. [config/herrenberg_stadtrad.json](../../config/herrenberg_stadtrad.json).
+The following properties are copied from the gbfs light system, if provided:
+
+* attribution_organization_name
+* attribution_url
+* feed_contact_email
+* opening_hours
+* language
+* license_id
+* license_url
+* name
+* email
+* operator
+* phone_number
+* privacy_last_updated
+* privacy_url
+* purchase_url
+* terms_last_updated
+* terms_url
+* timezone
+* url
+
+
+### vehicle_types.json
+
+Vehicle Types are extracted from the `system/vehicle_types` section:
+
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`vehicle_type_id` |  Normalized vehicle_type name.
+`form_factor` | `vehicle_type['form_factor']`
+`rider_capacity`| -
+`cargo_volume_capacity` | -
+`cargo_load_capacity` | -
+`propulsion_type` | `vehicle_type['propulsion_type']`.
+`eco_label` | -
+`max_range_meters` | `vehicle_type['max_range_meters']`, or `20000` if unset.
+`name` | `vehicle_type['name']`
+`g_CO2_km` | -
+`vehicle_image` | -
+`make` | -
+`model` | -
+`wheel_count` | -
+`max_permitted_speed` | -
+`rated_power` | -
+`default_reserve_time` | -
+`return_constraint`| `roundtrip_station`
+`vehicle_assets`| -
+`default_pricing_plan_id`| -
+`pricing_plan_ids`| -
+
+
+### station_information.json
+
+Station information is extracted from `system/stations` section.
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`station_id` | `station['id']`
+`name` | `station['name']`
+`short_name` | -
+`lat` | `station['lat']`
+`lon` | `station['lon']`
+`address` | `station['address']`
+`cross_street` | -
+`region_id` | -
+`post_code` |  `station['post_code']`
+`city` |  `station['city']` Note: `city` will be introduced with GBFS v3.1, we publish it nevertheless already with GBFSv2.3
+`rental_methods` | -
+`is_virtual_station`| -
+`station_area` | -
+`parking_type` | -
+`parking_hoop` | -
+`contact_phone` | -
+`capacity` | `station['capacity']`
+`vehicle_capacity`  |  -
+`vehicle_type_capacity` | for every vehicle type listed in `station['vehicle_types']` an entry with key corresponding to normalized vehicle type name and `station['vehicle_types'][n][available]`
+`is_valet_station`  | -
+`is_charging_station` |  -
+`rental_uris` | for web, `station['url']`, if provided
+
+
+
+### station_status.json
+
+Station information is extracted from `system/stations` section.
+
+#### Field Mappings
+
+GBFS Field | Mapping
+--- | ---
+`station_id` | `station['id']`
+`num_bikes_available` | sum of all `station["vehicle_types"]["available_count"]`
+`vehicle_types_available` | Per `station["vehicle_types"]`: `station["vehicle_types"]["available_count"]`, `vehicle_type_id` corresponds to normalised vehicle typr name, see `vehicle_types.json` above
+`num_docks_available` | -
+`vehicle_docks_available` | -
+`num_docks_disabled` | -
+`is_installed` | `True`
+`is_renting` | `True`
+`is_returning` | `True`
+`last_reported` | timestamp of now()
+
+
+### free_bike_status.json
+
+Feed is static, no free_bike_status is generated.
+
+### system_hours.json
+
+None.
+
+### system_calendar.json
+
+None.
+
+### system_regions.json
+
+None.
+
+### system_pricing_plans.json
+
+None.
+
+### system_alerts.json
+
+As defined in feed_config.
+
+### geofencing_zones.json
+
+None.
+
+## Deep Links
+
+None.

--- a/x2gbfs/gbfs/base_provider.py
+++ b/x2gbfs/gbfs/base_provider.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Any, Dict, Generator, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from x2gbfs.util import unidecode_with_german_umlauts
 
@@ -8,6 +8,47 @@ logger = logging.getLogger('x2gbfs.base_provider')
 
 
 class BaseProvider:
+
+    def __init__(self, feed_config: dict[str, Any]):
+        self.config = feed_config
+
+    def load_system_information(self) -> Dict[str, Any]:
+        """
+        Retrieves the system_information for this provider.
+        The default implementation returns the provider config's
+        feed_data/system_information section.
+
+        If the subclassed provider does not overwrite this
+        method, the config MUST contain a feed_data/system_information
+        section.
+
+        Custom implementations might use provider specific data
+        to provide system_information.
+        """
+        return self.config['feed_data']['system_information']
+
+    def load_pricing_plans(self) -> Optional[List[Dict[str, Any]]]:
+        """
+        Retrieves a list of pricing_plans for this provider.
+        The default implementation returns the provider config's
+        feed_data/pricing_plans section, if defined.
+
+        Custom implementations might use provider specific data
+        to provide pricing_plans.
+        """
+        return self.config.get('feed_data', {}).get('pricing_plans')
+
+    def load_alerts(self) -> Optional[List[Dict[str, Any]]]:
+        """
+        Retrieves a list of alerts for this provider.
+        The default implementation returns the provider config's
+        feed_data/alerts section, if defined.
+
+        Custom implementations might use provider specific data
+        to provide alerts.
+        """
+        return self.config.get('feed_data', {}).get('alerts')
+
     def load_stations(self, default_last_reported: int) -> Tuple[Optional[Dict], Optional[Dict]]:
         """
         Retrieves stations from the providers API and converts them

--- a/x2gbfs/gbfs/gbfs_transformer.py
+++ b/x2gbfs/gbfs/gbfs_transformer.py
@@ -12,6 +12,24 @@ class GbfsTransformer:
     # see https://wiki.openstreetmap.org/wiki/Precision_of_coordinates
     MAX_COORDINATE_PRECISION = 6
 
+    def load_system_information(self, provider: BaseProvider) -> Dict[str, Any]:
+        """
+        Loads system_information information from the provider.
+        """
+        return provider.load_system_information()
+
+    def load_pricing_plans(self, provider: BaseProvider) -> Optional[List[Dict[str, Any]]]:
+        """
+        Loads pricing plans information from the provider.
+        """
+        return provider.load_pricing_plans()
+
+    def load_alerts(self, provider: BaseProvider) -> Optional[List[Dict[str, Any]]]:
+        """
+        Loads alerts information from the provider.
+        """
+        return provider.load_alerts()
+
     def load_stations_and_vehicles(
         self, provider: BaseProvider
     ) -> Tuple[Optional[List], Optional[List], Optional[List], Optional[List], Optional[List], int]:

--- a/x2gbfs/gbfs/gbfs_writer.py
+++ b/x2gbfs/gbfs/gbfs_writer.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import logging
 from datetime import datetime
@@ -22,21 +21,19 @@ class GbfsWriter:
 
     def write_gbfs_feed(
         self,
-        config: Dict,
         destFolder: str,
+        system_information: Dict,
         station_information: Optional[List[Dict]],
         station_status: Optional[List[Dict]],
         vehicle_types: Optional[List[Dict]],
         vehicles: Optional[List[Dict]],
         geofencing_zones: Optional[List[Dict]],
+        pricing_plans: Optional[List[Dict]],
+        alerts: Optional[List[Dict]],
         base_url: str,
         timestamp: int,
         ttl: int = 60,
     ) -> None:
-        base_url = base_url or config['publication_base_url']
-        pricing_plans = config['feed_data'].get('pricing_plans')
-        alerts = config['feed_data'].get('alerts')
-        system_information = copy.deepcopy(config['feed_data']['system_information'])
         feed_language = system_information['language']
 
         Path(destFolder).mkdir(parents=True, exist_ok=True)

--- a/x2gbfs/providers/__init__.py
+++ b/x2gbfs/providers/__init__.py
@@ -4,6 +4,7 @@ from .deer import Deer
 from .example import ExampleProvider
 from .fleetster import FleetsterAPI
 from .free2move import Free2moveAPI, Free2moveProvider
+from .gbfslight import GbfsLightProvider
 from .lastenvelo_fr import LastenVeloFreiburgProvider
 from .moqo import MoqoProvider
 from .noi import NoiProvider

--- a/x2gbfs/providers/deer.py
+++ b/x2gbfs/providers/deer.py
@@ -40,9 +40,10 @@ class Deer(BaseProvider):
     CURRENT_RANGE_METERS = 50000
     IGNORABLE_BOOKING_STATES = ['canceled', 'rejected', 'keyreturned']
 
-    def __init__(self, api):
+    def __init__(self, feed_config: dict[str, Any], api):
+        self.config = feed_config
         self.api = api
-        self.stationIdCache = set()
+        self.stationIdCache: set[str] = set()
 
     def all_stations(self) -> Generator[Dict, None, None]:
         """

--- a/x2gbfs/providers/example.py
+++ b/x2gbfs/providers/example.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from x2gbfs.gbfs.base_provider import BaseProvider
 
@@ -35,8 +35,8 @@ class ExampleProvider(BaseProvider):
         }
     }
 
-    def __init__(self):
-        pass
+    def __init__(self, feed_config: dict[str, Any]):
+        self.config = feed_config
 
     def load_vehicles(self, default_last_reported: int) -> Tuple[Optional[Dict], Optional[Dict]]:
         """

--- a/x2gbfs/providers/gbfslight.py
+++ b/x2gbfs/providers/gbfslight.py
@@ -1,0 +1,150 @@
+import json
+import logging
+from typing import Any, Tuple
+
+from x2gbfs.gbfs.base_provider import BaseProvider
+from x2gbfs.util import get
+
+logger = logging.getLogger(__name__)
+
+
+def fix_url(url: str) -> str:
+    # Patch: Herrenberg currently uses Umlauts in their URL
+    # For now, we patch this here, but Herrenberg should fix this
+    # We explicitly do not urlencoding here, as this might break valid urls
+    # in the future.
+    return url.replace('ä', '%C3%A4')
+
+
+class GbfsLightProvider(BaseProvider):
+
+    DEFAULT_MAX_RANGE_METERS = 20000
+
+    gbfslight_data: dict[str, Any] | None = None
+
+    def __init__(self, feed_config: dict[str, Any]) -> None:
+        self.config = feed_config
+        self.url = feed_config['provider_data']['url']
+        self.system_id = feed_config['provider_data']['system_id']
+
+    def _load_system(self) -> dict[str, Any]:
+        if self.gbfslight_data is None:
+            self.gbfslight_data = get(self.url).json()
+        return next(system for system in self.gbfslight_data['system'] if system['system_id'] == self.system_id)
+
+    def load_system_information(self) -> dict[str, Any]:
+        """
+        Retrieves the system_information for this provider.
+        It merges the provider config's
+        feed_data/system_information section with information
+        provided via gbfs-light system.
+        """
+        config_system_information = super().load_system_information()
+        system = self._load_system()
+        system_information = {
+            # we use the configured, not the published system_id
+            'system_id': self.system_id
+        }
+        # todo for now skip terms and privacy last updated (see https://github.com/MobilityData/gbfs/pull/693)
+        for source_key in [
+            'attribution_organization_name',
+            'attribution_url',
+            'feed_contact_email',
+            'opening_hours',
+            'language',
+            'license_id',
+            'license_url',
+            'name',
+            'email',
+            'operator',
+            'phone_number',
+            'privacy_last_updated',
+            'privacy_url',
+            'purchase_url',
+            'terms_last_updated',
+            'terms_url',
+            'timezone',
+            'url',
+        ]:
+            if source_key in system:
+                system_information[source_key] = system[source_key]
+            elif self.gbfslight_data is not None and source_key in self.gbfslight_data:
+                system_information[source_key] = self.gbfslight_data[source_key]
+
+        # Patch: Herrenberg does not deliver dates in iso data format
+        for date_field in ['privacy_last_updated', 'terms_last_updated']:
+            if date_field in system_information and system_information[date_field].count('.') == 2:
+                date_components = system_information[date_field].split('.')
+                system_information[date_field] = f'{date_components[2]}-{date_components[1]}-{date_components[0]}'
+        if 'url' in system_information:
+            system_information['url'] = fix_url(system_information['url'])
+
+        # Published system information get's higher priority than configured
+        # Note: this requires savy publishers. In case this does not hold, we
+        # might need to switch or make precedence configurable
+        return system_information | config_system_information
+
+    def load_vehicles(self, default_last_reported: int) -> Tuple[dict | None, dict | None]:
+        system = self._load_system()
+
+        gbfs_vehicle_types_map = {}
+
+        gbfs_vehicles_map: dict[str, Any] = {}
+
+        for vt in system['vehicle_types']:
+            vehicle_type_id = self._normalize_id(vt['name'])
+
+            gbfs_vehicle_type = {
+                'vehicle_type_id': vehicle_type_id,
+                'form_factor': vt['form_factor'],
+                'propulsion_type': vt['propulsion_type'],
+                'max_range_meters': vt.get('max_range_meters') or self.DEFAULT_MAX_RANGE_METERS,
+                'name': vt['name'],
+                'return_constraint': 'roundtrip_station',
+            }
+
+            gbfs_vehicle_types_map[vehicle_type_id] = gbfs_vehicle_type
+
+        return gbfs_vehicle_types_map, gbfs_vehicles_map
+
+    def load_stations(self, default_last_reported: int) -> Tuple[dict | None, dict | None]:
+        gbfs_station_infos_map: dict[str, dict] = {}
+        gbfs_station_status_map: dict[str, dict] = {}
+
+        system = self._load_system()
+
+        for elem in system['stations']:
+            station_info = {
+                'station_id': elem['id'],
+                'lat': elem['lat'],
+                'lon': elem['lon'],
+                'name': elem['name'],
+                'address': elem.get('address'),
+                'post_code': elem.get('post_code'),
+                'city': elem.get('city'),
+                'capacity': elem['capacity'],
+                'vehicle_type_capacity': {
+                    self._normalize_id(vt['name']): vt['available_count'] for vt in elem['vehicle_types']
+                },
+            }
+
+            if 'url' in elem:
+                station_info['rental_uris'] = {'web': fix_url(elem['url'])}
+
+            station_status = {
+                'station_id': elem['id'],
+                'is_installed': True,
+                'is_renting': True,
+                'is_returning': True,
+                'last_reported': default_last_reported,
+                'num_bikes_available': sum([vt['available_count'] for vt in elem['vehicle_types']]),
+                'vehicle_types_available': [
+                    {'vehicle_type_id': self._normalize_id(vt['name']), 'count': vt['available_count']}
+                    for vt in elem['vehicle_types']
+                ],
+            }
+
+            gbfs_station_infos_map[elem['id']] = station_info
+            gbfs_station_status_map[elem['id']] = station_status
+
+        return gbfs_station_infos_map, gbfs_station_status_map

--- a/x2gbfs/providers/lastenvelo_fr.py
+++ b/x2gbfs/providers/lastenvelo_fr.py
@@ -36,6 +36,9 @@ class LastenVeloFreiburgProvider(BaseProvider):
 
     lastenvelo_csv: str = ''
 
+    def __init__(self, feed_config: dict[str, Any]):
+        self.config = feed_config
+
     def _load_lastenvelo_csv(self) -> None:
         response = requests.get(
             self.LASTENVELO_API_URL, headers={'User-Agent': 'x2gbfs +https://github.com/mobidata-bw/'}, timeout=5

--- a/x2gbfs/providers/noi.py
+++ b/x2gbfs/providers/noi.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import requests
 
@@ -13,8 +13,8 @@ class NoiProvider(BaseProvider):
     STATION_URL = 'https://mobility.api.opendatahub.com/v2/flat%2Cnode/CarsharingStation?limit=500&offset=0&shownull=false&distinct=true'
     CAR_URL = 'https://mobility.api.opendatahub.com/v2/flat%2Cnode/CarsharingCar?limit=500&offset=0&shownull=false&distinct=true'
 
-    def __init__(self):
-        pass
+    def __init__(self, feed_config: dict[str, Any]):
+        self.config = feed_config
 
     def load_vehicles(self, default_last_reported: int) -> Tuple[Optional[Dict], Optional[Dict]]:
         response = requests.get(self.CAR_URL, timeout=20)

--- a/x2gbfs/x2gbfs.py
+++ b/x2gbfs/x2gbfs.py
@@ -20,6 +20,7 @@ from x2gbfs.providers import (
     FleetsterAPI,
     Free2moveAPI,
     Free2moveProvider,
+    GbfsLightProvider,
     LastenVeloFreiburgProvider,
     MoqoProvider,
     NoiProvider,
@@ -71,6 +72,8 @@ def build_extractor(provider: str, feed_config: Dict[str, Any]) -> BaseProvider:
         return NoiProvider(feed_config)
     if provider.startswith('free2move_'):
         return Free2moveProvider(feed_config, Free2moveAPI())
+    if feed_config.get('x2gbfs', {}).get('provider') == 'gbfs-light':
+        return GbfsLightProvider(feed_config)
 
     raise ValueError(f'Unknown config {provider}')
 


### PR DESCRIPTION
This PR
- adds support for "GBFS-Light", a single file json format suggested by the city of Herrenberg to provide static bikesharing data via a single JSON file.
- refactors `pricing_plan`, `system_information` and `alerts` data retrieval: it moved form `GbfsWriter` to `BaseProvider`, so these can return dynamic information. Per default, these feeds are still retrieved from the feed config.

Note: this PR is still WIP, as some I'd suggest Herrenberg's GBFS-Light is changed as follows:

* rename `mail` to `email`
* move and rename `last_updated` from properties of `terms` and `privacy`  to `terms_last_updated` and `privacy_last_updated`  
*move and rename properties of `address`  (`street`, `plz`, `houseNo` and `city`) to `system.address`, `system.post_code`, `system.city`, to align it with GBFS standard
* add `system_id` to every `system`.
