### PR TITLE
Flinkster fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog lists most feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
+## 2025-06-06:
+- flinkster_carsharing fix: pricing plans for `other`
+
 ## 2025-05-23
 - add moqo provider `lara_to_go`
 

--- a/config/flinkster_carsharing.json
+++ b/config/flinkster_carsharing.json
@@ -66,6 +66,28 @@
                 "plan_id": "compact_car_hour_day",
                 "price": 1.00,
                 "url": "https://www.flinkster.de/de/tarife"
+            },
+            {
+                "currency": "EUR",
+                "description": "Stundentarif: 6,50€ zzgl. 0,34€/km und 1,00€ pro Ausleihvorgang. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "Kleinwagen - Stundentarif",
+                "per_min_pricing": [ { "start": 0, "interval": 60, "rate": 6.50 } ],
+                "per_km_pricing": [ { "start": 0, "interval": 1, "rate": 0.34 } ],
+                "plan_id": "other_hour_daytime",
+                "price": 1.00,
+                "url": "https://www.flinkster.de/de/tarife"
+            },
+            {
+                "currency": "EUR",
+                "description": "Tagestarif: 65,00€ / 44,00€ (ab dem 2. Tag) zzgl. 0,34€/km und 1,00€ pro Ausleihvorgang. Alle Angaben ohne Gewähr.",
+                "is_taxable": false,
+                "name": "Kleinwagen - Tagestarif",
+                "per_min_pricing": [ { "start": 0, "end": 1440, "interval": 1440, "rate": 65.00 }, { "start": 1441, "interval": 1440, "rate": 44.00 } ],
+                "per_km_pricing": [ { "start": 0, "interval": 1, "rate": 0.34 } ],
+                "plan_id": "other_hour_day",
+                "price": 1.00,
+                "url": "https://www.flinkster.de/de/tarife"
             }
         ],
         "system_information": {


### PR DESCRIPTION
workaround for wrong car_type `other`