### PR TITLE
fix: empty vehicle_types_available is list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The changelog lists most feature changes between each release. Search GitHub iss
 ## 2025-08-21
 
 - handle websocket errors
+- fix: MOQO provider: for stations without vehicles, `vehicle_types_available` was dict, now it's empty list
 
 ## 2025-08-11
 - add moqo provider `ford_carsharing_autohausbaur`

--- a/x2gbfs/providers/moqo.py
+++ b/x2gbfs/providers/moqo.py
@@ -159,7 +159,7 @@ class MoqoProvider(BaseProvider):
 
         gbfs_station_status_map[station_id] = {
             'num_bikes_available': 0,
-            'vehicle_types_available': {},
+            'vehicle_types_available': [],
             'is_renting': True,
             'is_installed': True,
             'is_returning': True,


### PR DESCRIPTION
This PR corrects the default value for `station_status.vehicle_types_available` to `[]` instead of `{}`.