### PR TITLE
Fix URLs containing spaces

### DIFF
--- a/x2gbfs/providers/cambio.py
+++ b/x2gbfs/providers/cambio.py
@@ -140,7 +140,7 @@ class CambioProvider(BaseProvider):
         """
         Guesses the propulsion type from vehicle name.
         """
-        station_name = unidecode_with_german_umlauts(elem['name'].lower())
+        station_name = unidecode_with_german_umlauts(elem['name'].lower()).replace(' ', '-')
         station_url = f"https://www.cambio-carsharing.de/stationen/station/{station_name}-{elem['id']}"
 
         return {


### PR DESCRIPTION
Fixes invalid URLs for cambio feeds, that could contain spaces.
See #327 for more details.